### PR TITLE
feat: add slice definitions file for libssl3 on jammy

### DIFF
--- a/release/22.04/slices/libssl3.yaml
+++ b/release/22.04/slices/libssl3.yaml
@@ -1,11 +1,14 @@
 package: libssl3
 
 slices:
-    libs:
-      contents:
-        /usr/lib/x86_64-linux-gnu/engines3/afalg.so:
-        /usr/lib/x86_64-linux-gnu/engines3/padlock.so:
-        /usr/lib/x86_64-linux-gnu/engines3/loader_attic.so:
-        /usr/lib/x86_64-linux-gnu/libcrypto.so.3:
-        /usr/lib/x86_64-linux-gnu/libssl.so.3:
-        /usr/lib/x86_64-linux-gnu/ossl-modules/legacy.so:
+  libs:
+    essential:
+      - libc6_libs
+      
+    contents:
+      /usr/lib/x86_64-linux-gnu/engines3/afalg.so:
+      /usr/lib/x86_64-linux-gnu/engines3/padlock.so:
+      /usr/lib/x86_64-linux-gnu/engines3/loader_attic.so:
+      /usr/lib/x86_64-linux-gnu/libcrypto.so.3:
+      /usr/lib/x86_64-linux-gnu/libssl.so.3:
+      /usr/lib/x86_64-linux-gnu/ossl-modules/legacy.so:


### PR DESCRIPTION
`libssl3` is needed for openssl