### PR TITLE
Update gitignore to work with test binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ chisel.yaml
 /.dotnet
 /.local
 /.nuget
-/bin
-/obj
+bin/
+obj/
 .vscode


### PR DESCRIPTION
The .gitignore file didn't specify the paths for the bin and obj sub-directories correctly. They're within the test directory, not at the repo root.