### PR TITLE
Add .gitattributes file to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set default behavior to automatically normalize line endings.
+* text eol=lf


### PR DESCRIPTION
This ensures that the Dockerfile can be built by default on Windows machines. Without this attributes file, the install-slices file will contain `\r\n` line endings when cloned on a Windows machine. The chisel tool doesn't properly parse that file because of that, complaining about the presence of `\r`.