### PR TITLE
App user changes

### DIFF
--- a/Dockerfile.runtime-deps
+++ b/Dockerfile.runtime-deps
@@ -4,20 +4,19 @@ FROM ubuntu:22.04 as builder
 ARG ROOTFS
 WORKDIR ${ROOTFS}
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN groupadd --system --gid=101 app; \
+    useradd --uid 101 --gid 101 --shell /bin/false --no-create-home --system app; \
+    mkdir -p "${ROOTFS}/output/etc"; \
+    tail -1 < /etc/passwd > "${ROOTFS}/output/etc/passwd"; \
+    tail -1 < /etc/group > "${ROOTFS}/output/etc/group"
 RUN apt-get update; \
-    apt-get install -y golang git; \
-    useradd -m app; \
-    chown -R app:app ${ROOTFS}
+    apt-get install -y golang git
 COPY install-slices .
-USER app
 RUN mkdir -p output; \
     git clone --depth 1 -b main https://github.com/canonical/chisel
 WORKDIR ${ROOTFS}/chisel
 RUN go build ./cmd/chisel; \
-    ./chisel cut --release ubuntu-22.04 --root "${ROOTFS}/output" $(cat "${ROOTFS}/install-slices"); \
-    mkdir -p "${ROOTFS}/output/etc"; \
-    tail -1 < /etc/passwd > "${ROOTFS}/output/etc/passwd"; \
-    tail -1 < /etc/group > "${ROOTFS}/output/etc/group"
+    ./chisel cut --release ubuntu-22.04 --root "${ROOTFS}/output" $(cat "${ROOTFS}/install-slices")
 
 FROM scratch 
 ARG ROOTFS


### PR DESCRIPTION
The app user that was being created had write access to the entire filesystem as a result of the following command: https://github.com/ubuntu-rocks/dotnet/blob/6f74e979da074d6318c965550cd9b1123fc4c1ab/Dockerfile.runtime-deps#L10

The intention of this base image is to have a non-root user without privileged access. But it actually had the ability to overwrite any system file; not what we want. So I've removed that command from the Dockerfile.

In addition, for the .NET app user we want it to be defined as a system user, not a normal user. I've changed this to explicitly define the group and user as system accounts. The 101 GID actually conflicts with a `_ssh` group that gets created as a result of installing these packages: https://github.com/ubuntu-rocks/dotnet/blob/6f74e979da074d6318c965550cd9b1123fc4c1ab/Dockerfile.runtime-deps#L8

To avoid that conflict and still keep the 101 ID in the final image, I've moved the creation of the group and user to be before package installation. And to make it easier to pull out the newly added lines from /etc/passwd and /etc/group, I've included that right away after creating the accounts. If we want to do that until after installing packages then the `_ssh` account would actually be listed last in the file, making it not as straightforward of an operation to pull out just the `app` account.