### PR TITLE
Set ASP.NET Core port to non-privileged number

### DIFF
--- a/Dockerfile.runtime-deps
+++ b/Dockerfile.runtime-deps
@@ -22,8 +22,8 @@ FROM scratch
 ARG ROOTFS
 COPY --from=builder "${ROOTFS}/output" /
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)


### PR DESCRIPTION
Since the runtime-deps Dockerfile is configured to run with a non-root user by default, the `ASPNETCORE_URLS` variable should be set to a non-priviledged port, one that will work by default with the user.