### PR TITLE
Add registry's READMEs

### DIFF
--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -29,8 +29,8 @@ _Tags in italics are not available in ubuntu/dotnet-aspnet but are shown here fo
 
 | Channel Tag | | | Currently | Architectures |
 |---|---|---|---|---|
- | `6.0-22.10_beta` &nbsp;&nbsp; |  | | ASP.NET 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
- | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | ASP.NET 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | `6.0-22.10_beta` &nbsp;&nbsp; |  | | ASP.NET 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
+ | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | ASP.NET 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64` |
 | _`track_risk`_ |
 
 Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.     

--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -11,6 +11,8 @@ Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deplo
 
 This image inherits its content from the `ubuntu/dotnet-deps` image and only adds the `aspnetcore-runtime-6.0` package from the Ubuntu archive.
 
+### About chiselled Ubuntu containers
+
 **This image does not include bash nor a package manager nor the .NET SDK.**
 Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
 

--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -68,9 +68,6 @@ FROM ubuntu.azurecr.io/dotnet-aspnet:6.0-22.10_edge
 WORKDIR /app
 COPY --from=builder /app ./
 
-ENV PORT 8080
-EXPOSE 8080
-
 ENTRYPOINT ["dotnet", "/app/dotnetcoresample.dll"]
 ```
 
@@ -80,7 +77,9 @@ Run the following commands with the Dockerfile example from above:
 git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world
 cd dotnetcore-docs-hello-world
 # copy the content from the example above into ./Dockerfile
-docker build -t my-dotnet-app-chiseled-ubuntu:22.04 .
+docker build . -t my-chiseled-aspnet-app:latest
+docker run -p 8080:8080 my-chiseled-aspnet-app:latest
+# access http://localhost:8080/
 ```
 
 <!-- 

--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -1,4 +1,4 @@
-# ASP.NET runtime | Chiselled Ubuntu
+# Chiselled Ubuntu for ASP.NET
 
 ASP.NET runtime image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of ASP.NET and Ubuntu LTS.     
 **This repository is free to use and exempted from per-user rate limits.**

--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -4,7 +4,7 @@ ASP.NET runtime image [from Canonical](https://ubuntu.com/security/docker-images
 **This repository is free to use and exempted from per-user rate limits.**
 
 
-## About ASP.NET runtime
+## About the ASP.NET runtime
 
 ASP.NET is an open source web framework, created by Microsoft, for building modern web apps and services with .NET.
 Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.     
@@ -29,7 +29,7 @@ _Tags in italics are not available in ubuntu/dotnet-aspnet but are shown here fo
 
 | Channel Tag | | | Currently | Architectures |
 |---|---|---|---|---|
- | `6.0-22.10_beta` &nbsp;&nbsp; |  | | ASP.NET 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
+ | `6.0-22.10_edge` &nbsp;&nbsp; |  | | ASP.NET 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
  | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | ASP.NET 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64` |
 | _`track_risk`_ |
 

--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -1,0 +1,102 @@
+# ASP.NET runtime | Chiselled Ubuntu
+
+ASP.NET runtime image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of ASP.NET and Ubuntu LTS.     
+**This repository is free to use and exempted from per-user rate limits.**
+
+
+## About ASP.NET runtime
+
+ASP.NET is an open source web framework, created by Microsoft, for building modern web apps and services with .NET.
+Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.     
+
+This image inherits its content from the `ubuntu/dotnet-deps` image and only adds the `aspnetcore-runtime-6.0` package from the Ubuntu archive.
+
+**This image does not include bash nor a package manager nor the .NET SDK.**
+Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
+
+If you're looking to publish a self-contained .NET app, please have a look at the `ubuntu/dotnet-deps` repository.
+If you're looking for the .NET runtime (without ASP.NET), please then look at the `ubuntu/dotnet-runtime` repository.
+
+
+## Tags and Architectures
+![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17)
+Up to 5 years free security maintenance on LTS channels.
+
+![ESM](https://assets.ubuntu.com/v1/572f3fbd-ESM%402x.png?h=17)
+Up to 10 years customer security maintenance `from canonical/dotnet-aspnet`. [Request access](https://ubuntu.com/security/docker-images#get-in-touch).
+
+_Tags in italics are not available in ubuntu/dotnet-aspnet but are shown here for completeness._
+
+| Channel Tag | | | Currently | Architectures |
+|---|---|---|---|---|
+ | `6.0-22.10_beta` &nbsp;&nbsp; |  | | ASP.NET 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | ASP.NET 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
+| _`track_risk`_ |
+
+Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.     
+Channels are ordered from the most stable to the least `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+
+### Commercial use and Extended Security Maintenance channels
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or writing to rocks@canonical.com).
+
+## Usage
+
+Use this image to layer your ASP.NET application relying on dependencies sourced from the Ubuntu distribution.
+
+See the following multi-stage Dockerfile, building an ASP.NET 6 app on Ubuntu 22.04
+and packaging it on top of `ubuntu/dotnet-aspnet:6.0-22.04_beta`:
+
+```Dockerfile
+FROM ubuntu:22.04 AS builder
+
+# install the .NET 6 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet6 ca-certificates
+
+# add your application code
+WORKDIR /source
+# using https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+COPY . .
+
+# publish your ASP.NET app
+RUN dotnet publish -c Release -o /app --self-contained false
+
+FROM ubuntu.azurecr.io/dotnet-aspnet:6.0-22.10_edge
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+ENV PORT 8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "/app/dotnetcoresample.dll"]
+```
+
+Run the following commands with the Dockerfile example from above:
+
+```sh
+git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+cd dotnetcore-docs-hello-world
+# copy the content from the example above into ./Dockerfile
+docker build -t my-dotnet-app-chiseled-ubuntu:22.04 .
+```
+
+<!-- 
+#### Parameters
+
+| Parameter | Description |
+|---|---|
+| `-e TZ=UTC` | Timezone. | -->
+
+## Bugs and feature requests
+
+If you find a bug in our image or want to request a specific feature, please file a bug here:
+
+[https://bugs.launchpad.net/ubuntu-docker-images/+filebug](https://bugs.launchpad.net/ubuntu-docker-images/+filebug)
+
+Please title the bug "`dotnet-aspnet: <issue summary>`". Make sure to include the digest of the image you are using, from:
+
+```sh
+docker images --no-trunc --quiet ubuntu/dotnet-aspnet:<tag>
+```
+

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -9,6 +9,8 @@
 The .NET deps image is a clean base image for developers to layer their self-contained .NET and ASP.NET applications. Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/).     
 It only includes the runtime dependencies required to run a standard self-contained .NET application: `ca-certificates`, `libc6`, `libgcc`, `libssl3`, `libstdc++6`, and `zlib1g`.     
 
+### About chiselled Ubuntu containers
+
 **This image does not include bash nor a package manager.**
 Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu).         
 

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -67,19 +67,18 @@ FROM ubuntu/dotnet-deps:6.0-22.04_beta
 WORKDIR /app
 COPY --from=builder /app ./
 
-ENV PORT 8080
-EXPOSE 8080
-
 ENTRYPOINT ["/app/dotnetcoresample"]
 ```
 
 Run the following commands with the Dockerfile example from above:
 
 ```sh
-git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world.git
 cd dotnetcore-docs-hello-world
 # copy the content from the example above into ./Dockerfile
-docker build -t my-dotnet-app-chiseled-ubuntu:22.04 .
+docker build . -t my-chiseled-aspnet-app:latest
+docker run -p 8080:8080 my-chiseled-aspnet-app:latest
+# access http://localhost:8080/
 ```
 
 <!-- 

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -28,7 +28,7 @@ _Tags in italics are not available in ubuntu/dotnet-deps but are shown here for 
 
 | Channel Tag | | | Currently | Architectures |
 |---|---|---|---|---|
- | `6.0-22.10_beta` &nbsp;&nbsp; |  | | .NET deps 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | `6.0-22.10_edge` &nbsp;&nbsp; |  | | .NET deps 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
  | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET deps 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
 | _`track_risk`_ |
 

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -1,0 +1,75 @@
+# .NET deps | Chiselled Ubuntu
+
+Current .NET deps Docker Image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and rolls to newer .NET deps or Ubuntu release. **This repository is free to use and exempted from per-user rate limits.**
+
+
+## About .NET deps
+
+The .NET deps image is a clean base image for developers to layer their self-contained .NET and ASP.NET applications. Read more from [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/). It only includes the runtime dependencies required to run a standard self-contained .NET application: `ca-certificates`, `libc6`, `libgcc`, `libssl3`, `libstdc++6`, and `zlib1g`.     
+
+**This image does not include bash nor a package manager.** Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](TODO).         
+
+Canonical and Microsoft partner together to deliver .NET to Ubuntu, read [more about the partnership](TODO) if you're interested in getting enterprise support.
+
+If you're looking for the .NET or the ASP.NET runtimes, please have a look at the `ubuntu/dotnet-runtime` and `ubuntu/dotnet-aspnet` images.
+
+
+## Tags and Architectures
+![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17)
+Up to 5 years free security maintenance on LTS channels.
+
+![ESM](https://assets.ubuntu.com/v1/572f3fbd-ESM%402x.png?h=17)
+Up to 10 years customer security maintenance `from canonical/dotnet-deps`. [Request access](https://ubuntu.com/security/docker-images#get-in-touch).
+
+_Tags in italics are not available in ubuntu/dotnet-deps but are shown here for completeness._
+
+| Channel Tag | | | Currently | Architectures |
+|---|---|---|---|---|
+ | **`6.0-22.10_beta`** &nbsp;&nbsp; |  | | .NET deps 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | `6.0-22.04_beta` &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET deps 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
+| _`track_risk`_ |
+
+Channel Tag shows the most stable channel for that track ordered `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+
+### Commercial use and Extended Security Maintenance channels
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or using rocks@canonical.com).
+
+## Usage
+
+Use this image to layer your self-contained .NET or ASP.NET application.
+
+```Dockerfile
+FROM ubuntu:22.04 AS builder
+# install the .NET SDK from the Ubuntu archive
+# - no need to clean the APT layers as this is an unpublished stage
+RUN apt-get update && apt-get install -y dotnet6
+# add your application code
+WORKDIR /sln
+COPY . .
+# export your .NET app as a self-contained artefact
+RUN dotnet publish -c Release -r linux-x64 -o /sln/artifacts -p:PublishTrimmed=True
+
+FROM ubuntu/dotnet-deps:6.0-22.04_stable
+WORKDIR /app
+COPY --from=builder ./sln/artifacts .
+ENTRYPOINT ["dotnet", "MyDotnetApp.dll"]
+```
+
+#### Parameters
+
+| Parameter | Description |
+|---|---|
+| `-e TZ=UTC` | Timezone. |
+
+## Bugs and feature requests
+
+If you find a bug in our image or want to request a specific feature, please file a bug here:
+
+[https://bugs.launchpad.net/ubuntu-docker-images/+filebug](https://bugs.launchpad.net/ubuntu-docker-images/+filebug)
+
+Please title the bug "`dotnet-deps: <issue summary>`". Make sure to include the digest of the image you are using, from:
+
+```sh
+docker images --no-trunc --quiet ubuntu/dotnet-deps:<tag>
+```
+

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -66,12 +66,12 @@ EXPOSE 8080
 
 ENTRYPOINT ["/app/dotnetcoresample"]
 ```
-
+<!-- 
 #### Parameters
 
 | Parameter | Description |
 |---|---|
-| `-e TZ=UTC` | Timezone. |
+| `-e TZ=UTC` | Timezone. | -->
 
 ## Bugs and feature requests
 

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -42,6 +42,9 @@ If your usage includes commercial redistribution or requires unavailable channel
 
 Use this image to layer your self-contained .NET or ASP.NET application.
 
+See the following multi-stage Dockerfile, building an ASP.NET app on Ubuntu 22.04
+and packaging it on top of `ubuntu/dotnet-deps:6.0-22.04_beta`:
+
 ```Dockerfile
 FROM ubuntu:22.04 AS builder
 
@@ -67,6 +70,16 @@ EXPOSE 8080
 
 ENTRYPOINT ["/app/dotnetcoresample"]
 ```
+
+Run the following commands with the Dockerfile example from above:
+
+```sh
+git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+cd dotnetcore-docs-hello-world
+# copy the content from the example above into ./Dockerfile
+docker build -t my-dotnet-app-chiseled-ubuntu:22.04 .
+```
+
 <!-- 
 #### Parameters
 

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -1,4 +1,4 @@
-# .NET deps | Chiselled Ubuntu
+# Chiselled Ubuntu for self-contained .NET
 
 .NET deps image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of .NET and Ubuntu LTS.     
 **This repository is free to use and exempted from per-user rate limits.**

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -1,17 +1,19 @@
 # .NET deps | Chiselled Ubuntu
 
-Current .NET deps Docker Image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and rolls to newer .NET deps or Ubuntu release. **This repository is free to use and exempted from per-user rate limits.**
+.NET deps image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of .NET and Ubuntu LTS.     
+**This repository is free to use and exempted from per-user rate limits.**
 
 
 ## About .NET deps
 
-The .NET deps image is a clean base image for developers to layer their self-contained .NET and ASP.NET applications. Read more from [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/). It only includes the runtime dependencies required to run a standard self-contained .NET application: `ca-certificates`, `libc6`, `libgcc`, `libssl3`, `libstdc++6`, and `zlib1g`.     
+The .NET deps image is a clean base image for developers to layer their self-contained .NET and ASP.NET applications. Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/).     
+It only includes the runtime dependencies required to run a standard self-contained .NET application: `ca-certificates`, `libc6`, `libgcc`, `libssl3`, `libstdc++6`, and `zlib1g`.     
 
 **This image does not include bash nor a package manager.** Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](TODO).         
 
-Canonical and Microsoft partner together to deliver .NET to Ubuntu, read [more about the partnership](TODO) if you're interested in getting enterprise support.
+Canonical and Microsoft [partner together](TODO) to deliver and support .NET on Ubuntu.
 
-If you're looking for the .NET or the ASP.NET runtimes, please have a look at the `ubuntu/dotnet-runtime` and `ubuntu/dotnet-aspnet` images.
+If you're looking for the .NET or the ASP.NET runtime images, please have a look at the `ubuntu/dotnet-runtime` and `ubuntu/dotnet-aspnet` repositories.
 
 
 ## Tags and Architectures
@@ -25,14 +27,15 @@ _Tags in italics are not available in ubuntu/dotnet-deps but are shown here for 
 
 | Channel Tag | | | Currently | Architectures |
 |---|---|---|---|---|
- | **`6.0-22.10_beta`** &nbsp;&nbsp; |  | | .NET deps 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
- | `6.0-22.04_beta` &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET deps 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | `6.0-22.10_beta` &nbsp;&nbsp; |  | | .NET deps 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET deps 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
 | _`track_risk`_ |
 
-Channel Tag shows the most stable channel for that track ordered `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.     
+Channels are ordered from the most stable to the least `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
 
 ### Commercial use and Extended Security Maintenance channels
-If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or using rocks@canonical.com).
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or writing to rocks@canonical.com).
 
 ## Usage
 

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -9,9 +9,10 @@
 The .NET deps image is a clean base image for developers to layer their self-contained .NET and ASP.NET applications. Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/).     
 It only includes the runtime dependencies required to run a standard self-contained .NET application: `ca-certificates`, `libc6`, `libgcc`, `libssl3`, `libstdc++6`, and `zlib1g`.     
 
-**This image does not include bash nor a package manager.** Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](TODO).         
+**This image does not include bash nor a package manager.**
+Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu).         
 
-Canonical and Microsoft [partner together](TODO) to deliver and support .NET on Ubuntu.
+Canonical and Microsoft [partner together](https://ubuntu.com/blog/install-dotnet-on-ubuntu) to deliver and support .NET on Ubuntu.
 
 If you're looking for the .NET or the ASP.NET runtime images, please have a look at the `ubuntu/dotnet-runtime` and `ubuntu/dotnet-aspnet` repositories.
 

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -49,9 +49,8 @@ See the following multi-stage Dockerfile, building a .NET 6 app on Ubuntu 22.04
 and packaging it on top of `ubuntu/dotnet-runtime:6.0-22.04_beta`:
 
 ```Dockerfile
-# Adapting the example code on
-# https://github.com/dotnet/samples/tree/main/core/console-apps/FibonacciBetterMsBuild
-# to use .NET 6 (<TargetFramework>net6.0</TargetFramework>)
+# Using the example code on
+# https://github.com/ubuntu-rocks/dotnet/tree/main/tests/app_helloworld-self-contained/
 
 FROM ubuntu:22.04 AS builder
 
@@ -61,7 +60,7 @@ RUN apt-get update && apt-get install -y dotnet6 ca-certificates
 
 # add your application code
 WORKDIR /source
-COPY . .
+COPY src/ .
 
 # publish your .NET app
 RUN dotnet publish -c Release -o /app
@@ -71,10 +70,16 @@ FROM ubuntu/dotnet-runtime:6.0-22.04_beta
 WORKDIR /app
 COPY --from=builder /app ./
 
-ENV PORT 8080
-EXPOSE 8080
+ENTRYPOINT ["dotnet", "/app/Hello.dll"]
+```
 
-ENTRYPOINT ["dotnet", "/app/Fibonacci.dll"]
+Run the following commands with the Dockerfile example from above:
+
+```sh
+git clone https://github.com/ubuntu-rocks/dotnet.git
+cd dotnet/tests/app_helloworld
+docker build . -t my-chiseled-dotnet-app:latest
+docker run my-chiseled-dotnet-app:latest
 ```
 
 <!-- 

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -11,6 +11,8 @@ Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deplo
 
 This image inherits its content from the `ubuntu/dotnet-deps` image and only adds the `dotnet-runtime-6.0` package from the Ubuntu archive.
 
+### About chiselled Ubuntu containers
+
 **This image does not include bash nor a package manager nor the .NET SDK.**
 Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
 

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -29,8 +29,8 @@ _Tags in italics are not available in ubuntu/dotnet-runtime but are shown here f
 
 | Channel Tag | | | Currently | Architectures |
 |---|---|---|---|---|
- | `6.0-22.10_beta` &nbsp;&nbsp; |  | | .NET runtime 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
- | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET runtime 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | `6.0-22.10_beta` &nbsp;&nbsp; |  | | .NET runtime 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
+ | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET runtime 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64` |
 | _`track_risk`_ |
 
 Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.     

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -1,0 +1,96 @@
+# .NET runtime | Chiselled Ubuntu
+
+.NET runtime image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of .NET and Ubuntu LTS.     
+**This repository is free to use and exempted from per-user rate limits.**
+
+
+## About .NET runtime
+
+.NET is a free, cross-platform, open source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
+Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.     
+
+This image inherits its content from the `ubuntu/dotnet-deps` image and only adds the `dotnet-runtime-6.0` package from the Ubuntu archive.
+
+**This image does not include bash nor a package manager nor the .NET SDK.**
+Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
+
+If you're looking to publish a self-contained .NET app, please have a look at the `ubuntu/dotnet-deps` repository.
+If you're looking to publish an ASP.NET app, please then look at the `ubuntu/dotnet-aspnet` repository.
+
+
+## Tags and Architectures
+![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17)
+Up to 5 years free security maintenance on LTS channels.
+
+![ESM](https://assets.ubuntu.com/v1/572f3fbd-ESM%402x.png?h=17)
+Up to 10 years customer security maintenance `from canonical/dotnet-runtime`. [Request access](https://ubuntu.com/security/docker-images#get-in-touch).
+
+_Tags in italics are not available in ubuntu/dotnet-runtime but are shown here for completeness._
+
+| Channel Tag | | | Currently | Architectures |
+|---|---|---|---|---|
+ | `6.0-22.10_beta` &nbsp;&nbsp; |  | | .NET runtime 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
+ | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET runtime 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64`, `arm64`, `ppc64el`, `s390x` |
+| _`track_risk`_ |
+
+Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.     
+Channels are ordered from the most stable to the least `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+
+### Commercial use and Extended Security Maintenance channels
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or writing to rocks@canonical.com).
+
+## Usage
+
+Use this image to layer your .NET application relying on dependencies sourced from the Ubuntu distribution.
+
+See the following multi-stage Dockerfile, building a .NET 6 app on Ubuntu 22.04
+and packaging it on top of `ubuntu/dotnet-runtime:6.0-22.04_beta`:
+
+```Dockerfile
+# Adapting the example code on
+# https://github.com/dotnet/samples/tree/main/core/console-apps/FibonacciBetterMsBuild
+# to use .NET 6 (<TargetFramework>net6.0</TargetFramework>)
+
+FROM ubuntu:22.04 AS builder
+
+# install the .NET 6 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet6 ca-certificates
+
+# add your application code
+WORKDIR /source
+COPY . .
+
+# publish your .NET app
+RUN dotnet publish -c Release -o /app
+
+FROM ubuntu/dotnet-runtime:6.0-22.04_beta
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+ENV PORT 8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "/app/Fibonacci.dll"]
+```
+
+<!-- 
+#### Parameters
+
+| Parameter | Description |
+|---|---|
+| `-e TZ=UTC` | Timezone. | -->
+
+## Bugs and feature requests
+
+If you find a bug in our image or want to request a specific feature, please file a bug here:
+
+[https://bugs.launchpad.net/ubuntu-docker-images/+filebug](https://bugs.launchpad.net/ubuntu-docker-images/+filebug)
+
+Please title the bug "`dotnet-runtime: <issue summary>`". Make sure to include the digest of the image you are using, from:
+
+```sh
+docker images --no-trunc --quiet ubuntu/dotnet-runtime:<tag>
+```
+

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -1,4 +1,4 @@
-# .NET runtime | Chiselled Ubuntu
+# Chiselled Ubuntu for .NET
 
 .NET runtime image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of .NET and Ubuntu LTS.     
 **This repository is free to use and exempted from per-user rate limits.**

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -4,7 +4,7 @@
 **This repository is free to use and exempted from per-user rate limits.**
 
 
-## About .NET runtime
+## About the .NET runtime
 
 .NET is a free, cross-platform, open source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
 Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.     
@@ -29,7 +29,7 @@ _Tags in italics are not available in ubuntu/dotnet-runtime but are shown here f
 
 | Channel Tag | | | Currently | Architectures |
 |---|---|---|---|---|
- | `6.0-22.10_beta` &nbsp;&nbsp; |  | | .NET runtime 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
+ | `6.0-22.10_edge` &nbsp;&nbsp; |  | | .NET runtime 6.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
  | **`6.0-22.04_beta`** &nbsp;&nbsp; | ![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17) | | .NET runtime 6.0 on Ubuntu&nbsp;22.04&nbsp;LTS| `amd64` |
 | _`track_risk`_ |
 

--- a/tests/app_helloworld/Dockerfile
+++ b/tests/app_helloworld/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04 AS builder
+
+# install the .NET 6 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet6 ca-certificates
+
+# add your application code
+WORKDIR /source
+COPY src/ .
+
+# publish your .NET app
+RUN dotnet publish -c Release -o /app
+
+FROM ubuntu.azurecr.io/dotnet-runtime:6.0-22.04_beta
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "/app/Hello.dll"]


### PR DESCRIPTION
fixes https://github.com/ubuntu-rocks/dotnet/issues/16
This is a WIP to include the registry's READMEs within the repo (unstructured, for now).

I started with `dotnet-deps`, as I needed to start somewhere, and will then do the same for `dotnet-runtime` and `dotnet-aspnet`.

@cjdcordeiro I'd need your help to review the usage example, information, and add to the "Parameters" section please.

Thanks!