### PR TITLE
Define home directory for default user

### DIFF
--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -18,8 +18,9 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \
@@ -43,6 +44,12 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
 
 FROM image-prep
+ARG USER UID GROUP GID
+
 COPY --from=sliced-aspnet /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-aspnet --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -18,8 +18,9 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \
@@ -43,6 +44,12 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
 
 FROM image-prep
+ARG USER UID GROUP GID
+
 COPY --from=sliced-aspnet /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-aspnet --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -18,8 +18,9 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \
@@ -44,6 +45,12 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     zlib1g_libs
 
 FROM image-prep
+ARG USER UID GROUP GID
+
 COPY --from=sliced-deps /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
 # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -18,8 +18,9 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \
@@ -44,6 +45,12 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     zlib1g_libs
 
 FROM image-prep
+ARG USER UID GROUP GID
+
 COPY --from=sliced-deps /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
 # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -18,8 +18,9 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \
@@ -43,6 +44,12 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
 
 FROM image-prep
+ARG USER UID GROUP GID
+
 COPY --from=sliced-runtime /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-runtime --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -18,8 +18,9 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \
@@ -43,6 +44,12 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
 
 FROM image-prep
+ARG USER UID GROUP GID
+
 COPY --from=sliced-runtime /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-runtime --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]


### PR DESCRIPTION
The `app` user that is defined in all the .NET chiseled containers does not have a home directory defined for it. This can be problematic since some tools that may be run in the container will expect the directory to exist.

These changes define a `/home/$USER` directory by default. The ownership of that directory is also set to `$USER`. However, due to https://github.com/moby/moby/issues/38710, that ownership is not preserved when `/rootfs` is copied to the final stage. The workaround used is to explicitly copy that directory using the `--chown` option to ensure it has the appropriate ownership for the non-root user.