### PR TITLE
Include root user

### DIFF
--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -19,10 +19,8 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
-    && echo "root:x:0:" >/rootfs/etc/group \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
-    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \

--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -19,7 +19,9 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo "root:x:0:" >/rootfs/etc/group \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
     && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -19,10 +19,8 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
-    && echo "root:x:0:" >/rootfs/etc/group \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
-    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -19,7 +19,9 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo "root:x:0:" >/rootfs/etc/group \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
     && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -19,10 +19,8 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
-    && echo "root:x:0:" >/rootfs/etc/group \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
-    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -19,7 +19,9 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo "root:x:0:" >/rootfs/etc/group \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
     && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -19,10 +19,8 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
-    && echo "root:x:0:" >/rootfs/etc/group \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
-    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -19,7 +19,9 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo "root:x:0:" >/rootfs/etc/group \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
     && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -19,10 +19,8 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
-    && echo "root:x:0:" >/rootfs/etc/group \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
-    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -19,7 +19,9 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo "root:x:0:" >/rootfs/etc/group \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
     && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -19,10 +19,8 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
-    && echo "root:x:0:" >/rootfs/etc/group \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
-    && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep
 ENV \

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -19,7 +19,9 @@ FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
 RUN mkdir -p /rootfs/etc \
     && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo "root:x:0:" >/rootfs/etc/group \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo "root:x:0:0:root:/root:/noshell" >/rootfs/etc/passwd \
     && echo "$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS image-prep

--- a/tests/app_helloworld-self-contained/runtest
+++ b/tests/app_helloworld-self-contained/runtest
@@ -5,4 +5,9 @@ echo "Running test for self-contained .NET Hello World app"
 
 (cd src && dotnet publish --self-contained -r linux-x64)
 
-docker run --rm -v $PWD/src:/app:ro --entrypoint /app/bin/Debug/net6.0/linux-x64/Hello $RUNTIME_DEPS_IMAGE
+RunContainer() {
+    docker run --rm -v $PWD/src:/app:ro --user $1 --entrypoint /app/bin/Debug/net6.0/linux-x64/Hello $RUNTIME_DEPS_IMAGE
+}
+
+RunContainer app
+RunContainer root

--- a/tests/app_helloworld/runtest
+++ b/tests/app_helloworld/runtest
@@ -5,4 +5,9 @@ echo "Running test for .NET Hello World app"
 
 (cd src && dotnet publish --no-self-contained -r linux-x64)
 
-docker run --rm -v $PWD/src:/app:ro $RUNTIME_IMAGE /app/bin/Debug/net6.0/linux-x64/Hello.dll
+RunContainer() {
+    docker run --rm -v $PWD/src:/app:ro --user $1 $RUNTIME_IMAGE /app/bin/Debug/net6.0/linux-x64/Hello.dll
+}
+
+RunContainer app
+RunContainer root

--- a/tests/web_helloworld/runtest
+++ b/tests/web_helloworld/runtest
@@ -5,23 +5,30 @@ echo "Running test for ASP.NET Core app "
 
 (cd src && dotnet publish --no-self-contained -r linux-x64)
 
-docker run -d -p 8000:8080 --name web_helloworld -v $PWD/src:/app:ro $ASPNET_IMAGE /app/bin/Debug/net6.0/linux-x64/Hello.dll
+RunContainer() {
+    docker run -d -p 8000:8080 --name web_helloworld -v $PWD/src:/app:ro --user $1 $ASPNET_IMAGE /app/bin/Debug/net6.0/linux-x64/Hello.dll
 
-# Allow time for web app to start
-sleep 5
+    # Allow time for web app to start
+    sleep 5
 
-# Send a request to the web app and verify the result
-ret=0
-curl http://localhost:8000/ | grep "Hello World!" || ret=1
+    # Send a request to the web app and verify the result
+    ret=0
+    curl http://localhost:8000/ | grep "Hello World!" || ret=1
 
-if [[ $ret -ne 0 ]]; then
-    echo "Failed to get response from app" >&2
-fi
+    if [[ $ret -ne 0 ]]; then
+        echo "Failed to get response from app" >&2
+    fi
 
-echo "Container log:"
-docker logs web_helloworld
+    echo "Container log:"
+    docker logs web_helloworld
 
-# Clean up container
-docker rm -f web_helloworld
+    # Clean up container
+    docker rm -f web_helloworld
 
-exit $ret
+    if [[ $ret -ne 0 ]]; then
+        exit $ret
+    fi
+}
+
+RunContainer app
+RunContainer root


### PR DESCRIPTION
The intent with the chiseled containers is to have a non-root user by default. As part of that implementation, the users that were actually registered in the container have been scoped down to just that non-root user app.

However, all of the files in the system are actually owned by the root user (technically owned by UID 0 since there is no user named root). So it's a bit odd that there are files in the container that are owned by a user that is not registered.

Not having a root user exist doesn't actually provide any sort of protection. The container can still be run with root-level permissions by running the container with --user 0 instead of --user root.

So to make things more correct and consistent, the root user will be included in the generated images.