### PR TITLE
feat: add os-release info to all images

### DIFF
--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -37,6 +37,7 @@ FROM rootfs-prep AS sliced-aspnet
 ARG UBUNTU_RELEASE
 RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
+    base-files_release-info \
     ca-certificates_data \
     aspnetcore-runtime-6.0_libs \
     && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -37,6 +37,7 @@ FROM rootfs-prep AS sliced-aspnet
 ARG UBUNTU_RELEASE
 RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
+    base-files_release-info \
     ca-certificates_data \
     aspnetcore-runtime-6.0_libs \
     && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -37,6 +37,7 @@ FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
 RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
+    base-files_release-info \
     ca-certificates_data \
     libc6_libs \
     libgcc-s1_libs \

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -37,6 +37,7 @@ FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
 RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
+    base-files_release-info \
     ca-certificates_data \
     libc6_libs \
     libgcc-s1_libs \

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -37,6 +37,7 @@ FROM rootfs-prep AS sliced-runtime
 ARG UBUNTU_RELEASE
 RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
+    base-files_release-info \
     ca-certificates_data \
     dotnet-runtime-6.0_libs \
     && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -37,6 +37,7 @@ FROM rootfs-prep AS sliced-runtime
 ARG UBUNTU_RELEASE
 RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
+    base-files_release-info \
     ca-certificates_data \
     dotnet-runtime-6.0_libs \
     && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \


### PR DESCRIPTION
Fixes https://github.com/ubuntu-rocks/dotnet/issues/80.

#### Changes proposed in this pull request:
 - install slice `base-files_release-info` into all images


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

