### PR TITLE
feat: remove binary symlinks from Dockerfiles

### DIFF
--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -40,9 +40,8 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_release-info \
     ca-certificates_data \
     aspnetcore-runtime-6.0_libs \
-    && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \
     && mkdir -p /rootfs/usr/bin \
-    && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -40,9 +40,8 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_release-info \
     ca-certificates_data \
     aspnetcore-runtime-6.0_libs \
-    && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \
     && mkdir -p /rootfs/usr/bin \
-    && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -40,9 +40,8 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_release-info \
     ca-certificates_data \
     dotnet-runtime-6.0_libs \
-    && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \
     && mkdir -p /rootfs/usr/bin \
-    && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -40,9 +40,8 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_release-info \
     ca-certificates_data \
     dotnet-runtime-6.0_libs \
-    && ln -sr /rootfs/usr/lib/dotnet/dotnet6-* /rootfs/usr/lib/dotnet/dotnet6 \
     && mkdir -p /rootfs/usr/bin \
-    && ln -s /usr/lib/dotnet/dotnet6/dotnet /rootfs/usr/bin/
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
 
 FROM image-prep
 ARG USER UID GROUP GID


### PR DESCRIPTION
With the recent updates to the .NET pkgs, we no longer need to manually create the symlink to the pkg binary.

#### Changes proposed in this pull request:
 - remove the manual symlinks to `/rootfs/usr/lib/dotnet/dotnet6-*`


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

