### PR TITLE
build .NET 6.0 chiselled images for arm64 (jammy and kinetic)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,23 @@ jobs:
 
       - name: Prepare working environment for running and collecting test results
         run: |
-          mkdir -p ${{ github.workspace }}/_test_results
           sudo apt-get update
           sudo apt-get -y install skopeo
+          pip install shyaml
 
       - uses: actions/setup-dotnet@v2
         with:
           dotnet-version: "6.0.x"
 
+      # Setup QEMU and Docker buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Lint the Dockerfiles
       - name: Lint the .NET runtime deps container image recipe
         uses: hadolint/hadolint-action@v2.0.0
         with:
@@ -49,26 +58,48 @@ jobs:
           dockerfile: dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }}
           ignore: DL3008,DL3015,SC3028
 
+      # Build images for multiple archs
       - name: Build the .NET runtime deps container image
         run: |
-          docker build \
-            -t ${{ env.runtime-deps-image-name }} \
+          set -x
+          archs=`cat rockcraft.*.dotnet-deps-6.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-deps.tar \
             -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
             dotnet-deps
 
+          skopeo copy oci-archive:dotnet-deps.tar docker-daemon:${{ env.runtime-deps-image-name }}
+
       - name: Build the .NET runtime container image
         run: |
-          docker build \
-            -t ${{ env.runtime-image-name }} \
+          set -x
+          archs=`cat rockcraft.*.dotnet-runtime-6.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-runtime.tar \
             -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
             dotnet-runtime
 
+          skopeo copy oci-archive:dotnet-runtime.tar docker-daemon:${{ env.runtime-image-name }}
+
       - name: Build the ASP.NET Core runtime container image
         run: |
-          docker build \
-            -t ${{ env.aspnet-image-name }} \
+          set -x
+          archs=`cat rockcraft.*.dotnet-aspnet-6.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-aspnet.tar \
             -f dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }} \
             dotnet-aspnet
+
+          skopeo copy oci-archive:dotnet-aspnet.tar docker-daemon:${{ env.aspnet-image-name }}
 
       - name: Run Tests
         working-directory: ${{ github.workspace }}/tests

--- a/rockcraft.2.dotnet-runtime-6.0-22.10.yaml
+++ b/rockcraft.2.dotnet-runtime-6.0-22.10.yaml
@@ -3,3 +3,5 @@ version: 6.0
 base: 22.10
 platforms:
   amd64:
+  arm64:
+    build-on: [amd64]

--- a/rockcraft.3.dotnet-aspnet-6.0-22.10.yaml
+++ b/rockcraft.3.dotnet-aspnet-6.0-22.10.yaml
@@ -3,3 +3,5 @@ version: 6.0
 base: 22.10
 platforms:
   amd64:
+  arm64:
+    build-on: [amd64]

--- a/rockcraft.5.dotnet-runtime-6.0-22.04.yaml
+++ b/rockcraft.5.dotnet-runtime-6.0-22.04.yaml
@@ -3,3 +3,5 @@ version: 6.0
 base: 22.04
 platforms:
   amd64:
+  arm64:
+    build-on: [amd64]

--- a/rockcraft.6.dotnet-aspnet-6.0-22.04.yaml
+++ b/rockcraft.6.dotnet-aspnet-6.0-22.04.yaml
@@ -3,3 +3,5 @@ version: 6.0
 base: 22.04
 platforms:
   amd64:
+  arm64:
+    build-on: [amd64]


### PR DESCRIPTION
Related to https://github.com/ubuntu-rocks/dotnet/issues/19.

#### Changes proposed in this pull request:
 - adds arm64 builds for dotnet-runtime and dotnet-aspnet chiselled images
 - adds multiarch builds to the CI tests

### slices info

There are no changes required to the Chisel releases, because the only differences between the DEBs are:

 - `dotnet-host` has `/usr/lib/dotnet/install_location_arm64` in arm64 and `/usr/lib/dotnet/install_location_x64` in amd64
  ```
  Files in second .deb but not in first
  -------------------------------------
  -rw-r--r--  root/root   /usr/lib/dotnet/install_location_arm64
  
  Files in first .deb but not in second
  -------------------------------------
  -rw-r--r--  root/root   /usr/lib/dotnet/install_location_x64
  
  ```

 - `dotnet-runtime-6.0` has `libunwind8` as a dependency in amd64 only
  
  ``` 
  Depends: dotnet-hostfxr-6.0, libicu71, libc6 (>= 2.36), libgcc-s1 (>= 3.0), liblttng-ust1 (>= 2.13.0), libssl3 (>= 3.0.0), libstdc++6 (>= 12), [-libunwind8,-] zlib1g (>= 1:1.1.4)
  ```

And none of these changes affects our builds.

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

![rock](https://miro.medium.com/max/1080/1*BZKWC3rbGMkKHKADbKXO1g.jpeg)
