### PR TITLE
Dotnet7 [kinetic, lunar]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,150 @@
+name: "Chiselled Ubuntu .NET7 Tests"
+
+on: push
+
+env:
+  runtime-deps-image-name: ubuntu/dotnet-deps:test
+  runtime-image-name: ubuntu/dotnet-runtime:test
+  aspnet-image-name: ubuntu/dotnet-aspnet:test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build and Test
+    outputs:
+      build_status: ${{ steps.set-outputs.outputs.status }}
+    strategy:
+      fail-fast: true
+      matrix:
+        ubuntu-release: ["22.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare working environment for running and collecting test results
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install skopeo
+          pip install shyaml
+
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: "7.0.x"
+
+      # Setup QEMU and Docker buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Lint the Dockerfiles
+      - name: Lint the .NET runtime deps container image recipe
+        uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }}
+          ignore: DL3008,DL3015,SC3028
+
+      - name: Lint the .NET runtime container image recipe
+        uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }}
+          ignore: DL3008,DL3015,SC3028
+
+      - name: Lint the ASP.NET Core runtime container image recipe
+        uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }}
+          ignore: DL3008,DL3015,SC3028
+
+      # Build images for multiple archs
+      - name: Build the .NET runtime deps container image
+        run: |
+          set -x
+          archs=`cat rockcraft.*.dotnet-deps-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-deps.tar \
+            -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
+            dotnet-deps
+
+          skopeo copy oci-archive:dotnet-deps.tar docker-daemon:${{ env.runtime-deps-image-name }}
+
+      - name: Build the .NET runtime container image
+        run: |
+          set -x
+          archs=`cat rockcraft.*.dotnet-runtime-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-runtime.tar \
+            -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
+            dotnet-runtime
+
+          skopeo copy oci-archive:dotnet-runtime.tar docker-daemon:${{ env.runtime-image-name }}
+
+      - name: Build the ASP.NET Core runtime container image
+        run: |
+          set -x
+          archs=`cat rockcraft.*.dotnet-aspnet-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-aspnet.tar \
+            -f dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }} \
+            dotnet-aspnet
+
+          skopeo copy oci-archive:dotnet-aspnet.tar docker-daemon:${{ env.aspnet-image-name }}
+
+      - name: Run Tests
+        working-directory: ${{ github.workspace }}/tests
+        run: |
+          ./run-all-tests ${{ env.runtime-deps-image-name }} ${{ env.runtime-image-name }} ${{ env.aspnet-image-name }}
+
+      - id: set-outputs
+        if: always()
+        run: |
+          echo "::set-output name=status::${{ job.status }}"
+
+  notify:
+    needs:
+      - build
+    if: always()
+    name: Post Workflow Status to Mattermost
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create the Mattermost Message
+        run: |
+          case "${{ needs.build.outputs.build_status }}" in
+            failure) msg_icon=":x:" ;;
+            success) msg_icon=":white_check_mark:" ;;
+            cancelled) msg_icon=":no_entry_sign:" ;;
+            *) msg_icon=":grey_question:" ;;
+          esac
+
+          msg=$(cat << EOF
+          ##### $msg_icon GitHub Workflow '${{ github.workflow	}}' execution [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has ended with the status \`${{ needs.build.outputs.build_status }}\`, for:
+           - Project: [${{ github.repository }}](${{ github.server_url }}/${{ github.repository }})
+           - Branch: [${{ github.ref_name }}](${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }})
+           - Commit: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}); _${{ github.event.head_commit.message }}_
+           - Triggered by: ${{ github.triggering_actor }}
+          EOF
+          )
+
+          jq -n --arg message "$msg" >mattermost.json '
+            {
+              text: $message,
+            }
+          '
+
+      - uses: slackapi/slack-github-action@v1.19.0
+        with:
+          payload-file-path: "mattermost.json"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.MATTERMOST_ROCKS_DEV_WEBHOOK_URL }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# .NET
+
+Ubuntu ROCKs for .NET.
+
+

--- a/dotnet-aspnet/.dockerignore
+++ b/dotnet-aspnet/.dockerignore
@@ -1,0 +1,2 @@
+tests
+README.md

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -1,0 +1,56 @@
+ARG UBUNTU_RELEASE=22.10
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM golang:1.18 AS chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+WORKDIR /opt/chisel
+RUN go generate internal/deb/version.go \
+    && go build ./cmd/chisel
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
+RUN git clone -b "ROCKS-358_dotnet7-kinetic" https://github.com/cjdcordeiro/chisel-releases.git
+###
+COPY --from=chisel /opt/chisel/chisel /usr/bin/
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ARG UID GID
+USER $UID:$GID
+
+### BOILERPLATE END ###
+
+FROM builder AS rootfs-prep
+ARG USER UID GROUP GID UBUNTU_RELEASE
+RUN mkdir /rootfs \
+    && chisel cut --release ./chisel-releases --root /rootfs \
+        base-files_base \
+        base-files_release-info \
+        ca-certificates_data \
+        aspnetcore-runtime-7.0_libs \
+    # need to rename binary, otherwise:
+    #  "A fatal error was encountered. Cannot execute dotnet when renamed to dotnet7."
+    && mv /rootfs/usr/lib/dotnet/dotnet7 /rootfs/usr/lib/dotnet/dotnet \
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM image-prep
+ARG USER UID GROUP GID
+COPY --from=rootfs-prep /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=rootfs-prep --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/dotnet-aspnet/Dockerfile.23.04
+++ b/dotnet-aspnet/Dockerfile.23.04
@@ -1,0 +1,56 @@
+ARG UBUNTU_RELEASE=23.04
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM golang:1.18 AS chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+WORKDIR /opt/chisel
+RUN go generate internal/deb/version.go \
+    && go build ./cmd/chisel
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
+RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
+###
+COPY --from=chisel /opt/chisel/chisel /usr/bin/
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ARG UID GID
+USER $UID:$GID
+
+### BOILERPLATE END ###
+
+FROM builder AS rootfs-prep
+ARG USER UID GROUP GID UBUNTU_RELEASE
+RUN mkdir /rootfs \
+    && chisel cut --release ./chisel-releases --root /rootfs \
+        base-files_base \
+        base-files_release-info \
+        ca-certificates_data \
+        aspnetcore-runtime-7.0_libs \
+    # need to rename binary, otherwise:
+    #  "A fatal error was encountered. Cannot execute dotnet when renamed to dotnet7."
+    && mv /rootfs/usr/lib/dotnet/dotnet7 /rootfs/usr/lib/dotnet/dotnet \
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM image-prep
+ARG USER UID GROUP GID
+COPY --from=rootfs-prep /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=rootfs-prep --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/dotnet-aspnet/LICENSE
+++ b/dotnet-aspnet/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dotnet-aspnet/README.md
+++ b/dotnet-aspnet/README.md
@@ -1,0 +1,9 @@
+# ASP.NET
+
+This ROCK is a tiny [Chiseled](https://github.com/canonical/chisel) Ubuntu container image, containing the [ASP.NET Core](https://dotnet.microsoft.com/en-us/apps/aspnet) and
+ [.NET](https://dotnet.microsoft.com/en-us/) runtime and libraries, for running ASP.NET Core applications in production.
+
+
+# References
+
+- [Microsoft's Ubuntu Jammy-based version of the ASP.NET container image](https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/6.0/jammy/amd64/Dockerfile)

--- a/dotnet-aspnet/USAGE.md
+++ b/dotnet-aspnet/USAGE.md
@@ -1,0 +1,102 @@
+# Chiselled Ubuntu for ASP.NET
+
+ASP.NET runtime image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of ASP.NET and Ubuntu LTS.
+**This repository is free to use and exempted from per-user rate limits.**
+
+
+## About the ASP.NET runtime
+
+ASP.NET is an open source web framework, created by Microsoft, for building modern web apps and services with .NET.
+Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.
+
+This image inherits its content from the `ubuntu/dotnet-deps` image and only adds the `aspnetcore-runtime-7.0` package from the Ubuntu archive.
+
+### About chiselled Ubuntu containers
+
+**This image does not include bash nor a package manager nor the .NET SDK.**
+Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
+
+If you're looking to publish a self-contained .NET app, please have a look at the `ubuntu/dotnet-deps` repository.
+If you're looking for the .NET runtime (without ASP.NET), please then look at the `ubuntu/dotnet-runtime` repository.
+
+
+## Tags and Architectures
+![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17)
+Up to 5 years free security maintenance on LTS channels.
+
+![ESM](https://assets.ubuntu.com/v1/572f3fbd-ESM%402x.png?h=17)
+Up to 10 years customer security maintenance `from canonical/dotnet-aspnet`. [Request access](https://ubuntu.com/security/docker-images#get-in-touch).
+
+_Tags in italics are not available in ubuntu/dotnet-aspnet but are shown here for completeness._
+
+| Channel Tag | | | Currently | Architectures |
+|---|---|---|---|---|
+ | `7.0-22.10_edge` &nbsp;&nbsp; |  | | ASP.NET 7.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
+| _`track_risk`_ |
+
+Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.
+Channels are ordered from the most stable to the least `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+
+### Commercial use and Extended Security Maintenance channels
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or writing to rocks@canonical.com).
+
+## Usage
+
+Use this image to layer your ASP.NET application relying on dependencies sourced from the Ubuntu distribution.
+
+See the following multi-stage Dockerfile, building an ASP.NET 7 app on Ubuntu 22.10
+and packaging it on top of `ubuntu/dotnet-aspnet:7.0-22.10_beta`:
+
+```Dockerfile
+FROM ubuntu:22.10 AS builder
+
+# install the .NET 7 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet7 ca-certificates
+
+# add your application code
+WORKDIR /source
+# using https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+COPY . .
+
+# publish your ASP.NET app
+RUN dotnet publish -c Release -o /app --self-contained false
+
+FROM ubuntu.azurecr.io/dotnet-aspnet:7.0-22.10_edge
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+ENTRYPOINT ["dotnet", "/app/dotnetcoresample.dll"]
+```
+
+Run the following commands with the Dockerfile example from above:
+
+```sh
+git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+cd dotnetcore-docs-hello-world
+# copy the content from the example above into ./Dockerfile
+docker build . -t my-chiseled-aspnet-app:latest
+docker run -p 8080:8080 my-chiseled-aspnet-app:latest
+# access http://localhost:8080/
+```
+
+<!-- 
+#### Parameters
+
+| Parameter | Description |
+|---|---|
+| `-e TZ=UTC` | Timezone. | -->
+
+## Bugs and feature requests
+
+If you find a bug in our image or want to request a specific feature, please file a bug here:
+
+[https://bugs.launchpad.net/ubuntu-docker-images/+filebug](https://bugs.launchpad.net/ubuntu-docker-images/+filebug)
+
+Please title the bug "`dotnet-aspnet: <issue summary>`". Make sure to include the digest of the image you are using, from:
+
+```sh
+docker images --no-trunc --quiet ubuntu/dotnet-aspnet:<tag>
+```
+

--- a/dotnet-deps/.dockerignore
+++ b/dotnet-deps/.dockerignore
@@ -1,0 +1,2 @@
+tests
+README.md

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -1,0 +1,54 @@
+ARG UBUNTU_RELEASE=22.10
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM golang:1.18 AS chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+WORKDIR /opt/chisel
+RUN go generate internal/deb/version.go \
+    && go build ./cmd/chisel
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=chisel /opt/chisel/chisel /usr/bin/
+
+FROM builder AS rootfs-prep
+ARG USER UID GROUP GID
+RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ARG UID GID
+USER $UID:$GID
+
+### BOILERPLATE END ###
+
+FROM rootfs-prep AS sliced-deps
+ARG UBUNTU_RELEASE
+RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+    base-files_base \
+    base-files_release-info \
+    ca-certificates_data \
+    libc6_libs \
+    libgcc-s1_libs \
+    libssl3_libs \
+    libstdc++6_libs \
+    zlib1g_libs
+
+FROM image-prep
+ARG USER UID GROUP GID
+COPY --from=sliced-deps /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER

--- a/dotnet-deps/Dockerfile.23.04
+++ b/dotnet-deps/Dockerfile.23.04
@@ -1,0 +1,56 @@
+ARG UBUNTU_RELEASE=23.04
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM golang:1.18 AS chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+WORKDIR /opt/chisel
+RUN go generate internal/deb/version.go \
+    && go build ./cmd/chisel
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=chisel /opt/chisel/chisel /usr/bin/
+
+FROM builder AS rootfs-prep
+ARG USER UID GROUP GID
+RUN mkdir -p /rootfs/etc \
+    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ARG UID GID
+USER $UID:$GID
+
+### BOILERPLATE END ###
+
+FROM rootfs-prep AS sliced-deps
+ARG UBUNTU_RELEASE
+RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+    base-files_base \
+    base-files_release-info \
+    ca-certificates_data \
+    libc6_libs \
+    libgcc-s1_libs \
+    libssl3_libs \
+    libstdc++6_libs \
+    zlib1g_libs
+
+FROM image-prep
+ARG USER UID GROUP GID
+
+COPY --from=sliced-deps /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER

--- a/dotnet-deps/LICENSE
+++ b/dotnet-deps/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dotnet-deps/README.md
+++ b/dotnet-deps/README.md
@@ -1,0 +1,8 @@
+# .NET Runtime Deps
+
+This ROCK is a tiny [Chiseled](https://github.com/canonical/chisel) Ubuntu container image, containing a set of native [.NET](https://dotnet.microsoft.com/en-us/) dependencies 
+and basic configurations, which are just enough for running [self-contained](https://docs.microsoft.com/en-us/dotnet/core/deploying/) .NET applications.
+
+# References
+
+- [Microsoft's Ubuntu Jammy-based version of the .NET Runtime Deps container image](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime-deps/6.0/jammy/amd64/Dockerfile)

--- a/dotnet-deps/USAGE.md
+++ b/dotnet-deps/USAGE.md
@@ -1,0 +1,101 @@
+# Chiselled Ubuntu for self-contained .NET
+
+.NET deps image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of .NET and Ubuntu LTS.
+**This repository is free to use and exempted from per-user rate limits.**
+
+
+## About .NET deps
+
+The .NET deps image is a clean base image for developers to layer their self-contained .NET and ASP.NET applications. Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/).
+It only includes the runtime dependencies required to run a standard self-contained .NET application: `ca-certificates`, `libc6`, `libgcc`, `libssl3`, `libstdc++6`, and `zlib1g`.
+
+### About chiselled Ubuntu containers
+
+**This image does not include bash nor a package manager.**
+Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
+
+Canonical and Microsoft [partner together](https://ubuntu.com/blog/install-dotnet-on-ubuntu) to deliver and support .NET on Ubuntu.
+
+If you're looking for the .NET or the ASP.NET runtime images, please have a look at the `ubuntu/dotnet-runtime` and `ubuntu/dotnet-aspnet` repositories.
+
+
+## Tags and Architectures
+![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17)
+Up to 5 years free security maintenance on LTS channels.
+
+![ESM](https://assets.ubuntu.com/v1/572f3fbd-ESM%402x.png?h=17)
+Up to 10 years customer security maintenance `from canonical/dotnet-deps`. [Request access](https://ubuntu.com/security/docker-images#get-in-touch).
+
+_Tags in italics are not available in ubuntu/dotnet-deps but are shown here for completeness._
+
+| Channel Tag | | | Currently | Architectures |
+|---|---|---|---|---|
+ | `7.0-22.10_edge` &nbsp;&nbsp; |  | | .NET deps 7.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64`, `arm64`, `ppc64el`, `s390x` |
+| _`track_risk`_ |
+
+Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.
+Channels are ordered from the most stable to the least `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+
+### Commercial use and Extended Security Maintenance channels
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or writing to rocks@canonical.com).
+
+## Usage
+
+Use this image to layer your self-contained .NET or ASP.NET application.
+
+See the following multi-stage Dockerfile, building an ASP.NET app on Ubuntu 22.10
+and packaging it on top of `ubuntu/dotnet-deps:7.0-22.10_beta`:
+
+```Dockerfile
+FROM ubuntu:22.10 AS builder
+
+# install the .NET 7 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet7 ca-certificates
+
+# add your application code
+WORKDIR /source
+# using https://github.com/Azure-Samples/dotnetcore-docs-hello-world
+COPY . .
+
+# export your .NET app as a self-contained artefact
+RUN dotnet publish -c Release -r linux-x64 --self-contained true -o /app
+
+FROM ubuntu/dotnet-deps:7.0-22.10_beta
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+ENTRYPOINT ["/app/dotnetcoresample"]
+```
+
+Run the following commands with the Dockerfile example from above:
+
+```sh
+git clone https://github.com/Azure-Samples/dotnetcore-docs-hello-world.git
+cd dotnetcore-docs-hello-world
+# copy the content from the example above into ./Dockerfile
+docker build . -t my-chiseled-aspnet-app:latest
+docker run -p 8080:8080 my-chiseled-aspnet-app:latest
+# access http://localhost:8080/
+```
+
+<!-- 
+#### Parameters
+
+| Parameter | Description |
+|---|---|
+| `-e TZ=UTC` | Timezone. | -->
+
+## Bugs and feature requests
+
+If you find a bug in our image or want to request a specific feature, please file a bug here:
+
+[https://bugs.launchpad.net/ubuntu-docker-images/+filebug](https://bugs.launchpad.net/ubuntu-docker-images/+filebug)
+
+Please title the bug "`dotnet-deps: <issue summary>`". Make sure to include the digest of the image you are using, from:
+
+```sh
+docker images --no-trunc --quiet ubuntu/dotnet-deps:<tag>
+```
+

--- a/dotnet-runtime/.dockerignore
+++ b/dotnet-runtime/.dockerignore
@@ -1,0 +1,2 @@
+tests
+README.md

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -1,0 +1,56 @@
+ARG UBUNTU_RELEASE=22.10
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM golang:1.18 AS chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+WORKDIR /opt/chisel
+RUN go generate internal/deb/version.go \
+    && go build ./cmd/chisel
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
+RUN git clone -b "ROCKS-358_dotnet7-kinetic" https://github.com/cjdcordeiro/chisel-releases.git
+###
+COPY --from=chisel /opt/chisel/chisel /usr/bin/
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ARG UID GID USER GROUP
+USER $UID:$GID
+
+### BOILERPLATE END ###
+
+FROM builder AS rootfs-prep
+ARG USER UID GROUP GID UBUNTU_RELEASE
+RUN mkdir /rootfs \
+    && chisel cut --release ./chisel-releases --root /rootfs \
+        base-files_base \
+        base-files_release-info \
+        ca-certificates_data \
+        dotnet-runtime-7.0_libs \
+    # need to rename binary, otherwise:
+    #  "A fatal error was encountered. Cannot execute dotnet when renamed to dotnet7."
+    && mv /rootfs/usr/lib/dotnet/dotnet7 /rootfs/usr/lib/dotnet/dotnet \
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    
+FROM image-prep
+ARG USER UID GROUP GID
+COPY --from=rootfs-prep /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=rootfs-prep --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/dotnet-runtime/Dockerfile.23.04
+++ b/dotnet-runtime/Dockerfile.23.04
@@ -1,0 +1,56 @@
+ARG UBUNTU_RELEASE=23.04
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM golang:1.18 AS chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+WORKDIR /opt/chisel
+RUN go generate internal/deb/version.go \
+    && go build ./cmd/chisel
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
+RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
+###
+COPY --from=chisel /opt/chisel/chisel /usr/bin/
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ARG UID GID USER GROUP
+USER $UID:$GID
+
+### BOILERPLATE END ###
+
+FROM builder AS rootfs-prep
+ARG USER UID GROUP GID UBUNTU_RELEASE
+RUN mkdir /rootfs \
+    && chisel cut --release ./chisel-releases --root /rootfs \
+        base-files_base \
+        base-files_release-info \
+        ca-certificates_data \
+        dotnet-runtime-7.0_libs \
+    # need to rename binary, otherwise:
+    #  "A fatal error was encountered. Cannot execute dotnet when renamed to dotnet7."
+    && mv /rootfs/usr/lib/dotnet/dotnet7 /rootfs/usr/lib/dotnet/dotnet \
+    && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+    
+FROM image-prep
+ARG USER UID GROUP GID
+COPY --from=rootfs-prep /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=rootfs-prep --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/dotnet-runtime/LICENSE
+++ b/dotnet-runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dotnet-runtime/README.md
+++ b/dotnet-runtime/README.md
@@ -1,0 +1,12 @@
+# .NET Runtime 
+
+This ROCK is a tiny [Chiseled](https://github.com/canonical/chisel) Ubuntu container image, containing the [.NET](https://dotnet.microsoft.com/en-us/) runtimes and libraries necessary 
+for running .NET applications in production.
+
+# Dependencies
+
+This image relies on the `dotnet-runtime-deps` ROCK, which is built and maintained separately.
+
+# References
+
+- [Microsoft's Ubuntu Jammy-based version of the .NET Runtime container image](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime/6.0/jammy/amd64/Dockerfile)

--- a/dotnet-runtime/USAGE.md
+++ b/dotnet-runtime/USAGE.md
@@ -1,0 +1,102 @@
+# Chiselled Ubuntu for .NET
+
+.NET runtime image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and tracks the newest combination of .NET and Ubuntu LTS.
+**This repository is free to use and exempted from per-user rate limits.**
+
+
+## About the .NET runtime
+
+.NET is a free, cross-platform, open source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
+Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.
+
+This image inherits its content from the `ubuntu/dotnet-deps` image and only adds the `dotnet-runtime-7.0` package from the Ubuntu archive.
+
+### About chiselled Ubuntu containers
+
+**This image does not include bash nor a package manager nor the .NET SDK.**
+Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
+
+If you're looking to publish a self-contained .NET app, please have a look at the `ubuntu/dotnet-deps` repository.
+If you're looking to publish an ASP.NET app, please then look at the `ubuntu/dotnet-aspnet` repository.
+
+
+## Tags and Architectures
+![LTS](https://assets.ubuntu.com/v1/0a5ff561-LTS%402x.png?h=17)
+Up to 5 years free security maintenance on LTS channels.
+
+![ESM](https://assets.ubuntu.com/v1/572f3fbd-ESM%402x.png?h=17)
+Up to 10 years customer security maintenance `from canonical/dotnet-runtime`. [Request access](https://ubuntu.com/security/docker-images#get-in-touch).
+
+_Tags in italics are not available in ubuntu/dotnet-runtime but are shown here for completeness._
+
+| Channel Tag | | | Currently | Architectures |
+|---|---|---|---|---|
+ | `7.0-22.10_edge` &nbsp;&nbsp; |  | | .NET runtime 7.0 on Ubuntu&nbsp;22.10&nbsp;| `amd64` |
+| _`track_risk`_ |
+
+Channel Tag shows the most stable channel for that track. A track is a combination of both the application version and the underlying Ubuntu series, eg `1.0-22.04`.
+Channels are ordered from the most stable to the least `stable`, `candidate`, `beta`, `edge`. More risky channels are always implicitly available. So if `beta` is listed, you can also pull `edge`. If `candidate` is listed, you can pull `beta` and `edge`. When `stable` is listed, all four are available. Images are guaranteed to progress through the sequence `edge`, `beta`, `candidate` before `stable`.
+
+### Commercial use and Extended Security Maintenance channels
+If your usage includes commercial redistribution or requires unavailable channels/versions, please [get in touch with the Canonical team](https://ubuntu.com/security/docker-images#get-in-touch) (or writing to rocks@canonical.com).
+
+## Usage
+
+Use this image to layer your .NET application relying on dependencies sourced from the Ubuntu distribution.
+
+See the following multi-stage Dockerfile, building a .NET 7 app on Ubuntu 22.10
+and packaging it on top of `ubuntu/dotnet-runtime:.0-22.10_beta`:
+
+```Dockerfile
+# Using the example code on
+# https://github.com/ubuntu-rocks/dotnet/tree/main/tests/app_helloworld-self-contained/
+
+FROM ubuntu:22.10 AS builder
+
+# install the .NET 7 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet7 ca-certificates
+
+# add your application code
+WORKDIR /source
+COPY src/ .
+
+# publish your .NET app
+RUN dotnet publish -c Release -o /app
+
+FROM ubuntu/dotnet-runtime:7.0-22.10_beta
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+ENTRYPOINT ["dotnet", "/app/Hello.dll"]
+```
+
+Run the following commands with the Dockerfile example from above:
+
+```sh
+git clone https://github.com/ubuntu-rocks/dotnet.git
+cd dotnet/tests/app_helloworld
+docker build . -t my-chiseled-dotnet-app:latest
+docker run my-chiseled-dotnet-app:latest
+```
+
+<!-- 
+#### Parameters
+
+| Parameter | Description |
+|---|---|
+| `-e TZ=UTC` | Timezone. | -->
+
+## Bugs and feature requests
+
+If you find a bug in our image or want to request a specific feature, please file a bug here:
+
+[https://bugs.launchpad.net/ubuntu-docker-images/+filebug](https://bugs.launchpad.net/ubuntu-docker-images/+filebug)
+
+Please title the bug "`dotnet-runtime: <issue summary>`". Make sure to include the digest of the image you are using, from:
+
+```sh
+docker images --no-trunc --quiet ubuntu/dotnet-runtime:<tag>
+```
+

--- a/rockcraft.1.dotnet-deps-7.0-22.10.yaml
+++ b/rockcraft.1.dotnet-deps-7.0-22.10.yaml
@@ -1,0 +1,11 @@
+name: dotnet-deps
+version: 7.0
+base: 22.10
+platforms:
+  amd64:
+  arm64:
+    build-on: [amd64]
+  ppc64le:
+    build-on: [amd64]
+  s390x:
+    build-on: [amd64]

--- a/rockcraft.2.dotnet-runtime-7.0-22.10.yaml
+++ b/rockcraft.2.dotnet-runtime-7.0-22.10.yaml
@@ -1,0 +1,7 @@
+name: dotnet-runtime
+version: 7.0
+base: 22.10
+platforms:
+  amd64:
+  arm64:
+    build-on: [amd64]

--- a/rockcraft.3.dotnet-aspnet-7.0-22.10.yaml
+++ b/rockcraft.3.dotnet-aspnet-7.0-22.10.yaml
@@ -1,0 +1,7 @@
+name: dotnet-aspnet
+version: 7.0
+base: 22.10
+platforms:
+  amd64:
+  arm64:
+    build-on: [amd64]

--- a/rockcraft.4.dotnet-deps-7.0-23.04.yaml
+++ b/rockcraft.4.dotnet-deps-7.0-23.04.yaml
@@ -1,0 +1,11 @@
+name: dotnet-deps
+version: 7.0
+base: 23.04
+platforms:
+  amd64:
+  arm64:
+    build-on: [amd64]
+  ppc64le:
+    build-on: [amd64]
+  s390x:
+    build-on: [amd64]

--- a/rockcraft.5.dotnet-runtime-7.0-23.04.yaml
+++ b/rockcraft.5.dotnet-runtime-7.0-23.04.yaml
@@ -1,0 +1,7 @@
+name: dotnet-runtime
+version: 7.0
+base: 23.04
+platforms:
+  amd64:
+  arm64:
+    build-on: [amd64]

--- a/rockcraft.6.dotnet-aspnet-7.0-23.04.yaml
+++ b/rockcraft.6.dotnet-aspnet-7.0-23.04.yaml
@@ -1,0 +1,7 @@
+name: dotnet-aspnet
+version: 7.0
+base: 23.04
+platforms:
+  amd64:
+  arm64:
+    build-on: [amd64]

--- a/tests/app_helloworld-self-contained/runtest
+++ b/tests/app_helloworld-self-contained/runtest
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+echo "Running test for self-contained .NET Hello World app"
+
+(cd src && dotnet publish --self-contained -r linux-x64)
+
+RunContainer() {
+    docker run --rm -v $PWD/src:/app:ro --user $1 --entrypoint /app/bin/Debug/net7.0/linux-x64/Hello $RUNTIME_DEPS_IMAGE
+}
+
+RunContainer app
+RunContainer root

--- a/tests/app_helloworld-self-contained/src/Hello.csproj
+++ b/tests/app_helloworld-self-contained/src/Hello.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/app_helloworld-self-contained/src/Program.cs
+++ b/tests/app_helloworld-self-contained/src/Program.cs
@@ -1,0 +1,1 @@
+﻿Console.WriteLine("Hello, World!");

--- a/tests/app_helloworld/Dockerfile
+++ b/tests/app_helloworld/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04 AS builder
+
+# install the .NET 6 SDK from the Ubuntu archive
+# (no need to clean the apt cache as this is an unpublished stage)
+RUN apt-get update && apt-get install -y dotnet6 ca-certificates
+
+# add your application code
+WORKDIR /source
+COPY src/ .
+
+# publish your .NET app
+RUN dotnet publish -c Release -o /app
+
+FROM ubuntu.azurecr.io/dotnet-runtime:6.0-22.04_beta
+
+WORKDIR /app
+COPY --from=builder /app ./
+
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "/app/Hello.dll"]

--- a/tests/app_helloworld/runtest
+++ b/tests/app_helloworld/runtest
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+echo "Running test for .NET Hello World app"
+
+(cd src && dotnet publish --no-self-contained -r linux-x64)
+
+RunContainer() {
+    docker run --rm -v $PWD/src:/app:ro --user $1 $RUNTIME_IMAGE /app/bin/Debug/net7.0/linux-x64/Hello.dll
+}
+
+RunContainer app
+RunContainer root

--- a/tests/app_helloworld/src/Hello.csproj
+++ b/tests/app_helloworld/src/Hello.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/app_helloworld/src/Program.cs
+++ b/tests/app_helloworld/src/Program.cs
@@ -1,0 +1,1 @@
+﻿Console.WriteLine("Hello, World!");

--- a/tests/app_https-client/runtest
+++ b/tests/app_https-client/runtest
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+echo "Running test for .NET HTTPS client app "
+
+(cd src && dotnet publish --no-self-contained -r linux-x64)
+
+docker run --rm -v $PWD/src:/app:ro $RUNTIME_IMAGE /app/bin/Debug/net7.0/linux-x64/Hello.dll

--- a/tests/app_https-client/src/Hello.csproj
+++ b/tests/app_https-client/src/Hello.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/app_https-client/src/Program.cs
+++ b/tests/app_https-client/src/Program.cs
@@ -1,0 +1,5 @@
+﻿using System;
+using System.Net.Http;
+
+HttpClient hc = new HttpClient(new HttpClientHandler { ClientCertificateOptions = ClientCertificateOption.Automatic });
+Console.WriteLine(hc.GetStringAsync("https://httpbin.org/ip").GetAwaiter().GetResult());

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex
+
+echo "Running tests..."
+
+export RUNTIME_DEPS_IMAGE=${1:-"ubuntu/dotnet-deps:test"}
+export RUNTIME_IMAGE=${2:-"ubuntu/dotnet-runtime:test"}
+export ASPNET_IMAGE=${3:-"ubuntu/dotnet-aspnet:test"}
+
+CURRENT_FOLDER="$(dirname $(readlink -f $0))"
+
+for test_folder in "$CURRENT_FOLDER"/*/
+do
+    pushd $test_folder
+
+    ./runtest
+
+    popd
+done

--- a/tests/web_helloworld/runtest
+++ b/tests/web_helloworld/runtest
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -ex
+
+echo "Running test for ASP.NET Core app "
+
+(cd src && dotnet publish --no-self-contained -r linux-x64)
+
+RunContainer() {
+    docker run -d -p 8000:8080 --name web_helloworld -v $PWD/src:/app:ro --user $1 $ASPNET_IMAGE /app/bin/Debug/net7.0/linux-x64/Hello.dll
+
+    # Allow time for web app to start
+    sleep 5
+
+    # Send a request to the web app and verify the result
+    ret=0
+    curl http://localhost:8000/ | grep "Hello World!" || ret=1
+
+    if [[ $ret -ne 0 ]]; then
+        echo "Failed to get response from app" >&2
+    fi
+
+    echo "Container log:"
+    docker logs web_helloworld
+
+    # Clean up container
+    docker rm -f web_helloworld
+
+    if [[ $ret -ne 0 ]]; then
+        exit $ret
+    fi
+}
+
+RunContainer app
+RunContainer root

--- a/tests/web_helloworld/src/Hello.csproj
+++ b/tests/web_helloworld/src/Hello.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tests/web_helloworld/src/Program.cs
+++ b/tests/web_helloworld/src/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/tests/web_helloworld/src/Properties/launchSettings.json
+++ b/tests/web_helloworld/src/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65090",
+      "sslPort": 44311
+    }
+  },
+  "profiles": {
+    "Hello": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7158;http://localhost:5108",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/web_helloworld/src/appsettings.Development.json
+++ b/tests/web_helloworld/src/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/web_helloworld/src/appsettings.json
+++ b/tests/web_helloworld/src/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Adding .NET7 chiselled images based on Lunar and Kinetic.

#### Changes proposed in this pull request:
 - `libicu` dropped from images, and added `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true`
 - adjusted the docs and filenames to be specific to version 7.0

**NOTE:** due to a Chisel conflict (yet to be fixed) between .NET6 and .NET7, the `dotnet` binary is temporarily being named as "/usr/lib/dotnet/dotnet7" and renamed to "/usr/lib/dotnet/dotnet" from within the Dockerfiles. This should change once the Chisel conflict is fixed.

Ref:
 - Draft Chisel release PRs, waiting for Chisel conflict to be fixed: 
   - https://github.com/canonical/chisel-releases/pull/33
   - https://github.com/canonical/chisel-releases/pull/32

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?


