### PR TITLE
Add renovate for keeping images up to date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "prHourlyLimit": 0,
+  "ignorePaths": [
+    "tests/*",
+    ".github/*"
+  ],
+  "packageRules": [
+    {
+      "description": "Group relevant Dockerfiles that are used for the Chiselled images",
+      "matchPaths": [
+        "dotnet-deps/Dockerfile*",
+        "dotnet-runtime/Dockerfile*",
+        "dotnet-aspnet/Dockerfile*"
+      ],
+      "groupName": "Dockerfiles of Chiselled images",
+      "enabled": true,
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "pinDigest"
+      ]
+    }
+  ],
+  "baseBranches": [
+    "/^channels\\/.*/"
+  ]
+}


### PR DESCRIPTION
needs https://github.com/ubuntu-rocks/dotnet/pull/101 and https://github.com/ubuntu-rocks/dotnet/pull/100
closes https://github.com/ubuntu-rocks/dotnet/pull/100

#### Changes proposed in this pull request:
 - add renovate config for checking all image-specific Dockerfiles, in order to update the Ubuntu bases images whenever there are updates


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
