### PR TITLE
Generate SBOMs during GH Workflow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set up Syft
+        uses: anchore/sbom-action/download-syft@v0
+
       # Lint the Dockerfiles
       - name: Lint the .NET runtime deps container image recipe
         uses: hadolint/hadolint-action@v3.1.0
@@ -100,6 +103,60 @@ jobs:
             dotnet-aspnet
 
           skopeo copy oci-archive:dotnet-aspnet.tar docker-daemon:${{ env.aspnet-image-name }}
+
+      - name: Generate SBOM for the .NET runtime deps container image
+        run: |
+          set -x
+          archs=`cat rockcraft.*.dotnet-deps-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-deps-sbom.tar \
+            -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-deps
+
+          skopeo copy oci-archive:dotnet-deps-sbom.tar docker-daemon:dotnet-deps:sbom
+          syft packages -o spdx-json docker:dotnet-deps:sbom > dotnet-deps-${{ matrix.ubuntu-release }}.sbom.json
+
+      - name: Generate SBOM for the .NET runtime container image
+        run: |
+          set -x
+          archs=`cat rockcraft.*.dotnet-runtime-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-runtime-sbom.tar \
+            -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-runtime
+
+          skopeo copy oci-archive:dotnet-runtime-sbom.tar docker-daemon:dotnet-runtime:sbom
+          syft packages -o spdx-json docker:dotnet-runtime:sbom > dotnet-runtime-${{ matrix.ubuntu-release }}.sbom.json
+
+      - name: Generate SBOM for the ASP.NET Core runtime container image
+        run: |
+          set -x
+          archs=`cat rockcraft.*.dotnet-aspnet-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
+          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-aspnet-sbom.tar \
+            -f dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-aspnet
+
+          skopeo copy oci-archive:dotnet-aspnet-sbom.tar docker-daemon:dotnet-aspnet:sbom
+          syft packages -o spdx-json docker:dotnet-aspnet:sbom > dotnet-aspnet-${{ matrix.ubuntu-release }}.sbom.json
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: SBOMs
+          path: dotnet-*.sbom.json
 
       - name: Run Tests
         working-directory: ${{ github.workspace }}/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.runtime-deps-image-name }}" \
-              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-7.0-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Build the .NET runtime container image
@@ -119,7 +119,7 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.runtime-image-name }}" \
-              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-7.0-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Build the ASP.NET Core runtime container image
@@ -148,7 +148,7 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.aspnet-image-name }}" \
-              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-7.0-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Upload SBOM artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Set up Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@v0.14.2
+        with:
+          syft-version: "v0.80.0"
 
       # Lint the Dockerfiles
       - name: Lint the .NET runtime deps container image recipe
@@ -76,6 +78,21 @@ jobs:
 
           skopeo copy oci-archive:dotnet-deps.tar docker-daemon:${{ env.runtime-deps-image-name }}
 
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-deps-sbom.tar \
+            -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-deps
+
+          for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-deps-sbom.tar oci-archive:"dotnet-deps-sbom.$arch.tar"
+            syft packages \
+              -o spdx-json \
+              --name "${{ env.runtime-deps-image-name }}" \
+              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+          done
+
       - name: Build the .NET runtime container image
         run: |
           set -x
@@ -89,6 +106,21 @@ jobs:
             dotnet-runtime
 
           skopeo copy oci-archive:dotnet-runtime.tar docker-daemon:${{ env.runtime-image-name }}
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-runtime-sbom.tar \
+            -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-runtime
+
+          for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-runtime-sbom.tar oci-archive:"dotnet-runtime-sbom.$arch.tar"
+            syft packages \
+              -o spdx-json \
+              --name "${{ env.runtime-image-name }}" \
+              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+          done
 
       - name: Build the ASP.NET Core runtime container image
         run: |
@@ -104,54 +136,6 @@ jobs:
 
           skopeo copy oci-archive:dotnet-aspnet.tar docker-daemon:${{ env.aspnet-image-name }}
 
-      - name: Generate SBOM for the .NET runtime deps container image
-        run: |
-          set -x
-          archs=`cat rockcraft.*.dotnet-deps-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
-          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
-
-          docker buildx build \
-            --platform=${buildx_platforms} \
-            --output type=oci,dest=dotnet-deps-sbom.tar \
-            -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
-            --target sbom-prep \
-            dotnet-deps
-
-          for arch in $archs; do
-            skopeo copy --override-arch "$arch" oci-archive:dotnet-deps-sbom.tar oci-archive:"dotnet-deps-sbom.$arch.tar"
-            syft packages \
-              -o spdx-json \
-              --name "${{ env.runtime-deps-image-name }}" \
-              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-${{ matrix.ubuntu-release }}.$arch.sbom.json"
-          done
-
-      - name: Generate SBOM for the .NET runtime container image
-        run: |
-          set -x
-          archs=`cat rockcraft.*.dotnet-runtime-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
-          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
-
-          docker buildx build \
-            --platform=${buildx_platforms} \
-            --output type=oci,dest=dotnet-runtime-sbom.tar \
-            -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
-            --target sbom-prep \
-            dotnet-runtime
-
-          for arch in $archs; do
-            skopeo copy --override-arch "$arch" oci-archive:dotnet-runtime-sbom.tar oci-archive:"dotnet-runtime-sbom.$arch.tar"
-            syft packages \
-              -o spdx-json \
-              --name "${{ env.runtime-image-name }}" \
-              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-${{ matrix.ubuntu-release }}.$arch.sbom.json"
-          done
-
-      - name: Generate SBOM for the ASP.NET Core runtime container image
-        run: |
-          set -x
-          archs=`cat rockcraft.*.dotnet-aspnet-7.0-${{ matrix.ubuntu-release }}.yaml | shyaml get-value platforms | shyaml keys`
-          buildx_platforms="linux/$(echo ${archs} | sed 's/ /,linux\//g')"
-
           docker buildx build \
             --platform=${buildx_platforms} \
             --output type=oci,dest=dotnet-aspnet-sbom.tar \
@@ -164,14 +148,14 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.aspnet-image-name }}" \
-              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v3
         with:
           name: SBOMs
-          path: dotnet-*.sbom.json
+          path: dotnet-*-root.sbom.spdx
 
       - name: Run Tests
         working-directory: ${{ github.workspace }}/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Run a local Docker registry
-        run: |
-          set -x
-          docker run -d -p 5000:5000 --restart=always --name registry registry:2
-
       - name: Set up Syft
         uses: anchore/sbom-action/download-syft@v0
 
@@ -117,18 +112,17 @@ jobs:
 
           docker buildx build \
             --platform=${buildx_platforms} \
-            -t localhost:5000/dotnet-deps:sbom \
+            --output type=oci,dest=dotnet-deps-sbom.tar \
             -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
             --target sbom-prep \
-            --push \
             dotnet-deps
 
           for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-deps-sbom.tar oci-archive:"dotnet-deps-sbom.$arch.tar"
             syft packages \
               -o spdx-json \
-              --platform "linux/$arch" \
               --name "${{ env.runtime-deps-image-name }}" \
-              localhost:5000/dotnet-deps:sbom > "dotnet-deps-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-${{ matrix.ubuntu-release }}.$arch.sbom.json"
           done
 
       - name: Generate SBOM for the .NET runtime container image
@@ -139,18 +133,17 @@ jobs:
 
           docker buildx build \
             --platform=${buildx_platforms} \
-            -t localhost:5000/dotnet-runtime:sbom \
+            --output type=oci,dest=dotnet-runtime-sbom.tar \
             -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
             --target sbom-prep \
-            --push \
             dotnet-runtime
 
           for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-runtime-sbom.tar oci-archive:"dotnet-runtime-sbom.$arch.tar"
             syft packages \
               -o spdx-json \
-              --platform "linux/$arch" \
               --name "${{ env.runtime-image-name }}" \
-              localhost:5000/dotnet-runtime:sbom > "dotnet-runtime-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-${{ matrix.ubuntu-release }}.$arch.sbom.json"
           done
 
       - name: Generate SBOM for the ASP.NET Core runtime container image
@@ -161,25 +154,18 @@ jobs:
 
           docker buildx build \
             --platform=${buildx_platforms} \
-            -t localhost:5000/dotnet-aspnet:sbom \
+            --output type=oci,dest=dotnet-aspnet-sbom.tar \
             -f dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }} \
             --target sbom-prep \
-            --push \
             dotnet-aspnet
 
           for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-aspnet-sbom.tar oci-archive:"dotnet-aspnet-sbom.$arch.tar"
             syft packages \
               -o spdx-json \
-              --platform "linux/$arch" \
               --name "${{ env.aspnet-image-name }}" \
-              localhost:5000/dotnet-aspnet:sbom > "dotnet-aspnet-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-${{ matrix.ubuntu-release }}.$arch.sbom.json"
           done
-
-      - name: Stop and remove local Docker registry
-        run: |
-          set -x
-          docker container stop registry
-          docker container rm -v registry
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ubuntu-release: ["22.10"]
+        ubuntu-release: ["22.10", "23.04"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Run a local Docker registry
+        run: |
+          set -x
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
       - name: Set up Syft
         uses: anchore/sbom-action/download-syft@v0
 
@@ -112,13 +117,19 @@ jobs:
 
           docker buildx build \
             --platform=${buildx_platforms} \
-            --output type=oci,dest=dotnet-deps-sbom.tar \
+            -t localhost:5000/dotnet-deps:sbom \
             -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
             --target sbom-prep \
+            --push \
             dotnet-deps
 
-          skopeo copy oci-archive:dotnet-deps-sbom.tar docker-daemon:dotnet-deps:sbom
-          syft packages -o spdx-json docker:dotnet-deps:sbom > dotnet-deps-${{ matrix.ubuntu-release }}.sbom.json
+          for arch in $archs; do
+            syft packages \
+              -o spdx-json \
+              --platform "linux/$arch" \
+              --name "${{ env.runtime-deps-image-name }}" \
+              localhost:5000/dotnet-deps:sbom > "dotnet-deps-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+          done
 
       - name: Generate SBOM for the .NET runtime container image
         run: |
@@ -128,13 +139,19 @@ jobs:
 
           docker buildx build \
             --platform=${buildx_platforms} \
-            --output type=oci,dest=dotnet-runtime-sbom.tar \
+            -t localhost:5000/dotnet-runtime:sbom \
             -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
             --target sbom-prep \
+            --push \
             dotnet-runtime
 
-          skopeo copy oci-archive:dotnet-runtime-sbom.tar docker-daemon:dotnet-runtime:sbom
-          syft packages -o spdx-json docker:dotnet-runtime:sbom > dotnet-runtime-${{ matrix.ubuntu-release }}.sbom.json
+          for arch in $archs; do
+            syft packages \
+              -o spdx-json \
+              --platform "linux/$arch" \
+              --name "${{ env.runtime-image-name }}" \
+              localhost:5000/dotnet-runtime:sbom > "dotnet-runtime-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+          done
 
       - name: Generate SBOM for the ASP.NET Core runtime container image
         run: |
@@ -144,13 +161,25 @@ jobs:
 
           docker buildx build \
             --platform=${buildx_platforms} \
-            --output type=oci,dest=dotnet-aspnet-sbom.tar \
+            -t localhost:5000/dotnet-aspnet:sbom \
             -f dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }} \
             --target sbom-prep \
+            --push \
             dotnet-aspnet
 
-          skopeo copy oci-archive:dotnet-aspnet-sbom.tar docker-daemon:dotnet-aspnet:sbom
-          syft packages -o spdx-json docker:dotnet-aspnet:sbom > dotnet-aspnet-${{ matrix.ubuntu-release }}.sbom.json
+          for arch in $archs; do
+            syft packages \
+              -o spdx-json \
+              --platform "linux/$arch" \
+              --name "${{ env.aspnet-image-name }}" \
+              localhost:5000/dotnet-aspnet:sbom > "dotnet-aspnet-${{ matrix.ubuntu-release }}.$arch.sbom.json"
+          done
+
+      - name: Stop and remove local Docker registry
+        run: |
+          set -x
+          docker container stop registry
+          docker container rm -v registry
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ env:
   runtime-deps-image-name: ubuntu/dotnet-deps:test
   runtime-image-name: ubuntu/dotnet-runtime:test
   aspnet-image-name: ubuntu/dotnet-aspnet:test
+  dotnet-version: "7.0"
 
 jobs:
   build:
@@ -90,7 +91,7 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.runtime-deps-image-name }}" \
-              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-7.0-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-${{ env.dotnet-version }}-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Build the .NET runtime container image
@@ -119,7 +120,7 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.runtime-image-name }}" \
-              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-7.0-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-${{ env.dotnet-version }}-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Build the ASP.NET Core runtime container image
@@ -148,7 +149,7 @@ jobs:
             syft packages \
               -o spdx-json \
               --name "${{ env.aspnet-image-name }}" \
-              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-7.0-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-${{ env.dotnet-version }}-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
           done
 
       - name: Upload SBOM artifacts

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -10,28 +10,21 @@
 #   CHISEL_CACHE_DIR          (optional) the path which chisel will use to store it's cache
 #   CHISEL_DPKG_STATUS_FILE   (required) the path where the dpkg status file should be generated
 
-set -e
+set -eu
 
-CHISEL_BIN="${CHISEL_BIN:-"./chisel"}"
-CHISEL_CACHE_DIR="${CHISEL_CACHE_DIR:-".chisel-cache"}"
-CHISEL_DPKG_STATUS_FILE="${CHISEL_DPKG_STATUS_FILE}"
+CHISEL_BIN="${CHISEL_BIN:-"chisel"}"
+CHISEL_CACHE_DIR="${CHISEL_CACHE_DIR:-"$(mktemp -d)"}"
 
 _print_error() {
-	echo "Error: $@" >> /dev/stderr
-}
-
-_cleanup_cache() {
-	if [ -d "${CHISEL_CACHE_DIR}" ]; then
-		rm -rf "${CHISEL_CACHE_DIR}"
-	fi
+	echo "Error:" "$@" >> /dev/stderr
 }
 
 _install_slices() {
-	XDG_CACHE_HOME="${CHISEL_CACHE_DIR}" ${CHISEL_BIN} cut "$@"
+	XDG_CACHE_HOME="$CHISEL_CACHE_DIR" $CHISEL_BIN cut "$@"
 }
 
 _prepare_dpkg_status() {
-	local dir="${CHISEL_CACHE_DIR}/chisel/sha256"
+	dir="$CHISEL_CACHE_DIR/chisel/sha256"
 	if [ ! -d "$dir" ]; then
 		_print_error "could not find the chisel cache at ${dir}"
 		exit 1
@@ -42,12 +35,12 @@ _prepare_dpkg_status() {
 	fi
 
 	for f in "$dir"/*; do
-		local is_deb="$(file "$f" | grep "Debian binary package" | cat)"
+		is_deb="$(file "$f" | grep "Debian binary package" | cat)"
 		if [ -z "$is_deb" ]; then
 			continue
 		fi
-		dpkg-deb -f "$f" >> "${CHISEL_DPKG_STATUS_FILE}"
-		echo "" >> "${CHISEL_DPKG_STATUS_FILE}"
+		dpkg-deb -f "$f" >> "$CHISEL_DPKG_STATUS_FILE"
+		echo "" >> "$CHISEL_DPKG_STATUS_FILE"
 	done
 }
 
@@ -56,7 +49,5 @@ if [ -z "$CHISEL_DPKG_STATUS_FILE" ] ; then
 	exit 1
 fi
 
-_cleanup_cache
 _install_slices "$@"
 _prepare_dpkg_status
-_cleanup_cache

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# USAGE:
+#   ./<script-name> [ chisel-cut-OPTIONS ] <slices..>
+# Installs the slices, using
+#   chisel cut "$@"
+# Generates a status file similar to /var/lib/dpkg/status at the CHISEL_DPKG_STATUS_FILE path
+# env vars:
+#   CHISEL_BIN                (optional) the path of chisel binary
+#   CHISEL_CACHE_DIR          (optional) the path which chisel will use to store it's cache
+#   CHISEL_DPKG_STATUS_FILE   (required) the path where the dpkg status file should be generated
+
+set -e
+
+CHISEL_BIN="${CHISEL_BIN:-"./chisel"}"
+CHISEL_CACHE_DIR="${CHISEL_CACHE_DIR:-".chisel-cache"}"
+CHISEL_DPKG_STATUS_FILE="${CHISEL_DPKG_STATUS_FILE}"
+
+_print_error() {
+	echo "Error: $@" >> /dev/stderr
+}
+
+_cleanup_cache() {
+	if [ -d "${CHISEL_CACHE_DIR}" ]; then
+		rm -rf "${CHISEL_CACHE_DIR}"
+	fi
+}
+
+_install_slices() {
+	XDG_CACHE_HOME="${CHISEL_CACHE_DIR}" ${CHISEL_BIN} cut "$@"
+}
+
+_prepare_dpkg_status() {
+	local dir="${CHISEL_CACHE_DIR}/chisel/sha256"
+	if [ ! -d "$dir" ]; then
+		_print_error "could not find the chisel cache at ${dir}"
+		exit 1
+	fi
+
+	if [ -f "$CHISEL_DPKG_STATUS_FILE" ]; then
+		rm -f "$CHISEL_DPKG_STATUS_FILE"
+	fi
+
+	for f in "$dir"/*; do
+		local is_deb="$(file "$f" | grep "Debian binary package" | cat)"
+		if [ -z "$is_deb" ]; then
+			continue
+		fi
+		dpkg-deb -f "$f" >> "${CHISEL_DPKG_STATUS_FILE}"
+		echo "" >> "${CHISEL_DPKG_STATUS_FILE}"
+	done
+}
+
+if [ -z "$CHISEL_DPKG_STATUS_FILE" ] ; then
+	_print_error "please specify the desired path of dpkg status in CHISEL_DPKG_STATUS_FILE"
+	exit 1
+fi
+
+_cleanup_cache
+_install_slices "$@"
+_prepare_dpkg_status
+_cleanup_cache

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -7,8 +7,8 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 ### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
-    && chmod +x chisel-cut
+RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
+    && chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -20,7 +20,7 @@ RUN apt-get update \
 RUN git clone -b "ROCKS-358_dotnet7-kinetic" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -38,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -6,17 +6,21 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+### TODO: REMOVE the following once the script is moved elsewhere
+RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
+    && chmod +x chisel-cut
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 ### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
 RUN git clone -b "ROCKS-358_dotnet7-kinetic" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -34,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && chisel cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \
@@ -46,6 +50,10 @@ RUN mkdir /rootfs \
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM scratch AS sbom-prep
+COPY --from=rootfs-prep /rootfs /
+COPY --from=rootfs-prep /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -6,9 +6,8 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
-### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
-    && chmod +x chisel-wrapper
+ADD "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -38,7 +37,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
+    && CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-aspnet/Dockerfile.23.04
+++ b/dotnet-aspnet/Dockerfile.23.04
@@ -6,17 +6,21 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+### TODO: REMOVE the following once the script is moved elsewhere
+RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
+    && chmod +x chisel-cut
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 ### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
 RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -34,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && chisel cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \
@@ -46,6 +50,10 @@ RUN mkdir /rootfs \
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM scratch AS sbom-prep
+COPY --from=rootfs-prep /rootfs /
+COPY --from=rootfs-prep /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-aspnet/Dockerfile.23.04
+++ b/dotnet-aspnet/Dockerfile.23.04
@@ -6,9 +6,8 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
-### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
-    && chmod +x chisel-wrapper
+ADD "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -38,7 +37,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
+    && CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-aspnet/Dockerfile.23.04
+++ b/dotnet-aspnet/Dockerfile.23.04
@@ -7,8 +7,8 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 ### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
-    && chmod +x chisel-cut
+RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
+    && chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -20,7 +20,7 @@ RUN apt-get update \
 RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -38,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -7,8 +7,8 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 ### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
-    && chmod +x chisel-cut
+RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
+    && chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -17,7 +17,7 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -41,7 +41,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -6,9 +6,8 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
-### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
-    && chmod +x chisel-wrapper
+ADD "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -41,7 +40,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -6,14 +6,18 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+### TODO: REMOVE the following once the script is moved elsewhere
+RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
+    && chmod +x chisel-cut
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -37,7 +41,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
@@ -46,6 +50,10 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     libssl3_libs \
     libstdc++6_libs \
     zlib1g_libs
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-deps /rootfs /
+COPY --from=sliced-deps /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-deps/Dockerfile.23.04
+++ b/dotnet-deps/Dockerfile.23.04
@@ -6,9 +6,8 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
-### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
-    && chmod +x chisel-wrapper
+ADD "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -41,7 +40,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \

--- a/dotnet-deps/Dockerfile.23.04
+++ b/dotnet-deps/Dockerfile.23.04
@@ -6,14 +6,18 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+### TODO: REMOVE the following once the script is moved elsewhere
+RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
+    && chmod +x chisel-cut
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -37,7 +41,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
@@ -46,6 +50,10 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     libssl3_libs \
     libstdc++6_libs \
     zlib1g_libs
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-deps /rootfs /
+COPY --from=sliced-deps /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-deps/Dockerfile.23.04
+++ b/dotnet-deps/Dockerfile.23.04
@@ -7,8 +7,8 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 ### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
-    && chmod +x chisel-cut
+RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
+    && chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -17,7 +17,7 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -41,7 +41,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -7,8 +7,8 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 ### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
-    && chmod +x chisel-cut
+RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
+    && chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -20,7 +20,7 @@ RUN apt-get update \
 RUN git clone -b "ROCKS-358_dotnet7-kinetic" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -38,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -6,17 +6,21 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+### TODO: REMOVE the following once the script is moved elsewhere
+RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
+    && chmod +x chisel-cut
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 ### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
 RUN git clone -b "ROCKS-358_dotnet7-kinetic" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -34,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && chisel cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \
@@ -46,6 +50,10 @@ RUN mkdir /rootfs \
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM scratch AS sbom-prep
+COPY --from=rootfs-prep /rootfs /
+COPY --from=rootfs-prep /status /var/lib/dpkg/status
     
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -6,9 +6,8 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
-### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
-    && chmod +x chisel-wrapper
+ADD "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -38,7 +37,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
+    && CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-runtime/Dockerfile.23.04
+++ b/dotnet-runtime/Dockerfile.23.04
@@ -6,9 +6,8 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
-### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
-    && chmod +x chisel-wrapper
+ADD "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -38,7 +37,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
+    && CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \

--- a/dotnet-runtime/Dockerfile.23.04
+++ b/dotnet-runtime/Dockerfile.23.04
@@ -6,17 +6,21 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+### TODO: REMOVE the following once the script is moved elsewhere
+RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
+    && chmod +x chisel-cut
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 ### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
 RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -34,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && chisel cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \
@@ -46,6 +50,10 @@ RUN mkdir /rootfs \
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+
+FROM scratch AS sbom-prep
+COPY --from=rootfs-prep /rootfs /
+COPY --from=rootfs-prep /status /var/lib/dpkg/status
     
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-runtime/Dockerfile.23.04
+++ b/dotnet-runtime/Dockerfile.23.04
@@ -7,8 +7,8 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 ### TODO: REMOVE the following once the script is moved elsewhere
-RUN wget -q "https://raw.githubusercontent.com/rebornplusplus/chisel/dpkg-status/install.sh" -O chisel-cut \
-    && chmod +x chisel-cut
+RUN wget -q "https://raw.githubusercontent.com/ubuntu-rocks/dotnet/channels/7.0/edge/chisel-wrapper" \
+    && chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:79cbe0fc854e88942ae531d707cbf14fdb2179d4196c56d56122f5020690737d AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
@@ -20,7 +20,7 @@ RUN apt-get update \
 RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
 ###
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-cut /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM scratch AS image-prep
 ENV \
@@ -38,7 +38,7 @@ USER $UID:$GID
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
-    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-cut --release ./chisel-releases --root /rootfs \
+    && CHISEL_BIN=/usr/bin/chisel CHISEL_CACHE_DIR=.cache CHISEL_DPKG_STATUS_FILE=/status chisel-wrapper --release ./chisel-releases --root /rootfs \
         base-files_base \
         base-files_release-info \
         ca-certificates_data \


### PR DESCRIPTION
Addresses _ROCKS-646_ on Jira.

#### Changes proposed in this pull request:
After building the `dotnet-*` images, use [syft](https://github.com/anchore/syft) to generate SBOMs and upload them as artifacts in the GitHub Workflow.

-----

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
![image](https://github.com/ubuntu-rocks/dotnet/assets/18555205/c1e34e1f-87a7-4f36-ace0-01e1d1a52872)
