### PR TITLE
feat: generate SBOMs for 6.0 during workflow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ env:
   runtime-deps-image-name: ubuntu/dotnet-deps:test
   runtime-image-name: ubuntu/dotnet-runtime:test
   aspnet-image-name: ubuntu/dotnet-aspnet:test
+  dotnet-version: "6.0"
 
 jobs:
   build:
@@ -38,6 +39,11 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Set up Syft
+        uses: anchore/sbom-action/download-syft@v0.14.2
+        with:
+          syft-version: "v0.80.0"
 
       # Lint the Dockerfiles
       - name: Lint the .NET runtime deps container image recipe
@@ -73,6 +79,21 @@ jobs:
 
           skopeo copy oci-archive:dotnet-deps.tar docker-daemon:${{ env.runtime-deps-image-name }}
 
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-deps-sbom.tar \
+            -f dotnet-deps/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-deps
+
+          for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-deps-sbom.tar oci-archive:"dotnet-deps-sbom.$arch.tar"
+            syft packages \
+              -o spdx-json \
+              --name "${{ env.runtime-deps-image-name }}" \
+              oci-archive:"dotnet-deps-sbom.$arch.tar" > "dotnet-deps-${{ env.dotnet-version }}-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+          done
+
       - name: Build the .NET runtime container image
         run: |
           set -x
@@ -87,6 +108,21 @@ jobs:
 
           skopeo copy oci-archive:dotnet-runtime.tar docker-daemon:${{ env.runtime-image-name }}
 
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-runtime-sbom.tar \
+            -f dotnet-runtime/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-runtime
+
+          for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-runtime-sbom.tar oci-archive:"dotnet-runtime-sbom.$arch.tar"
+            syft packages \
+              -o spdx-json \
+              --name "${{ env.runtime-image-name }}" \
+              oci-archive:"dotnet-runtime-sbom.$arch.tar" > "dotnet-runtime-${{ env.dotnet-version }}-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+          done
+
       - name: Build the ASP.NET Core runtime container image
         run: |
           set -x
@@ -100,6 +136,27 @@ jobs:
             dotnet-aspnet
 
           skopeo copy oci-archive:dotnet-aspnet.tar docker-daemon:${{ env.aspnet-image-name }}
+
+          docker buildx build \
+            --platform=${buildx_platforms} \
+            --output type=oci,dest=dotnet-aspnet-sbom.tar \
+            -f dotnet-aspnet/Dockerfile.${{ matrix.ubuntu-release }} \
+            --target sbom-prep \
+            dotnet-aspnet
+
+          for arch in $archs; do
+            skopeo copy --override-arch "$arch" oci-archive:dotnet-aspnet-sbom.tar oci-archive:"dotnet-aspnet-sbom.$arch.tar"
+            syft packages \
+              -o spdx-json \
+              --name "${{ env.aspnet-image-name }}" \
+              oci-archive:"dotnet-aspnet-sbom.$arch.tar" > "dotnet-aspnet-${{ env.dotnet-version }}-${{ matrix.ubuntu-release }}-oci-$arch-root.sbom.spdx"
+          done
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: SBOMs
+          path: dotnet-*-root.sbom.spdx
 
       - name: Run Tests
         working-directory: ${{ github.workspace }}/tests

--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -6,14 +6,17 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:dc0d5441e7cf0f2015bede5eccac3a95b8cb8264c47aeb48f6d1d04b453b4177 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -35,13 +38,17 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-aspnet
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
     aspnetcore-runtime-6.0_libs \
     && mkdir -p /rootfs/usr/bin \
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-aspnet /rootfs /
+COPY --from=sliced-aspnet /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-aspnet/Dockerfile.22.10
+++ b/dotnet-aspnet/Dockerfile.22.10
@@ -6,14 +6,17 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -35,13 +38,17 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-aspnet
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
     aspnetcore-runtime-6.0_libs \
     && mkdir -p /rootfs/usr/bin \
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-aspnet /rootfs /
+COPY --from=sliced-aspnet /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -6,14 +6,17 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:dc0d5441e7cf0f2015bede5eccac3a95b8cb8264c47aeb48f6d1d04b453b4177 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -35,7 +38,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
@@ -44,6 +47,10 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     libssl3_libs \
     libstdc++6_libs \
     zlib1g_libs
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-deps /rootfs /
+COPY --from=sliced-deps /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-deps/Dockerfile.22.10
+++ b/dotnet-deps/Dockerfile.22.10
@@ -6,14 +6,17 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -35,7 +38,7 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-deps
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
@@ -44,6 +47,10 @@ RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     libssl3_libs \
     libstdc++6_libs \
     zlib1g_libs
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-deps /rootfs /
+COPY --from=sliced-deps /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -6,14 +6,17 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:dc0d5441e7cf0f2015bede5eccac3a95b8cb8264c47aeb48f6d1d04b453b4177 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -35,13 +38,17 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-runtime
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
     dotnet-runtime-6.0_libs \
     && mkdir -p /rootfs/usr/bin \
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-runtime /rootfs /
+COPY --from=sliced-runtime /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID

--- a/dotnet-runtime/Dockerfile.22.10
+++ b/dotnet-runtime/Dockerfile.22.10
@@ -6,14 +6,17 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
+RUN chmod +x chisel-wrapper
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:4bbd3b5e2a496751e7e5fcb20957d1bdfacff59cc4d4c1243a3a644046f34dd7 AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
+COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
 FROM builder AS rootfs-prep
 ARG USER UID GROUP GID
@@ -35,13 +38,17 @@ USER $UID:$GID
 
 FROM rootfs-prep AS sliced-runtime
 ARG UBUNTU_RELEASE
-RUN chisel cut --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
+RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
     ca-certificates_data \
     dotnet-runtime-6.0_libs \
     && mkdir -p /rootfs/usr/bin \
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
+
+FROM scratch AS sbom-prep
+COPY --from=sliced-runtime /rootfs /
+COPY --from=sliced-runtime /status /var/lib/dpkg/status
 
 FROM image-prep
 ARG USER UID GROUP GID


### PR DESCRIPTION
#### Changes proposed in this pull request:

After building the dotnet-* images, use [syft](https://github.com/anchore/syft) to generate SBOMs and upload them as artifacts in the GitHub Workflow.

_(Equivalent PRs for 7.0: https://github.com/ubuntu-rocks/dotnet/pull/246 followed by https://github.com/ubuntu-rocks/dotnet/pull/252)._

---

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---

*Picture of a cool ROCK:*
![image](https://github.com/ubuntu-rocks/dotnet/assets/18555205/f8d6bab5-1615-48bf-a449-6b960c7f996d)
