### PR TITLE
refactor(6.0): simplify build recipe

### DIFF
--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -1,43 +1,25 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=app UID=101 GROUP=app GID=101
 
-FROM golang:1.20 AS chisel
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
-RUN chmod +x chisel-wrapper
-
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:c6871ae8b54fb3ed0ba4df4eb98527e9a6692088fe0c2f2260a9334853092b47 AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
+RUN chmod +x /usr/bin/chisel-wrapper
+
 RUN mkdir -p /rootfs/etc \
-    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && install -d -m 0755 -o "$UID" -g "$GID" "/rootfs/home/$USER" \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
-FROM scratch AS image-prep
-ENV \
-    # Configure web servers to bind to port 8080 when present
-    ASPNETCORE_URLS=http://+:8080 \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true
-ARG UID GID
-USER $UID:$GID
-
-### BOILERPLATE END ###
-
-FROM rootfs-prep AS sliced-aspnet
-ARG UBUNTU_RELEASE
 RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -47,16 +29,21 @@ RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_R
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
 
 FROM scratch AS sbom-prep
-COPY --from=sliced-aspnet /rootfs /
-COPY --from=sliced-aspnet /status /var/lib/dpkg/status
+COPY --from=builder /rootfs /
+COPY --from=builder /status /var/lib/dpkg/status
 
-FROM image-prep
+FROM scratch
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
 ARG USER UID GROUP GID
 
-COPY --from=sliced-aspnet /rootfs /
+COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=sliced-aspnet --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown="$UID:$GID" "/rootfs/home/$USER" "/home/$USER"
 
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -1,43 +1,24 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=app UID=101 GROUP=app GID=101
 
-FROM golang:1.20 AS chisel
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
-RUN chmod +x chisel-wrapper
-
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:c6871ae8b54fb3ed0ba4df4eb98527e9a6692088fe0c2f2260a9334853092b47 AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
+RUN chmod +x /usr/bin/chisel-wrapper
+
 RUN mkdir -p /rootfs/etc \
-    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && install -d -m 0755 -o "$UID" -g "$GID" "/rootfs/home/$USER" \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
-FROM scratch AS image-prep
-ENV \
-    # Configure web servers to bind to port 8080 when present
-    ASPNETCORE_URLS=http://+:8080 \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true
-ARG UID GID
-USER $UID:$GID
-
-### BOILERPLATE END ###
-
-FROM rootfs-prep AS sliced-deps
-ARG UBUNTU_RELEASE
 RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -49,16 +30,21 @@ RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_R
     zlib1g_libs
 
 FROM scratch AS sbom-prep
-COPY --from=sliced-deps /rootfs /
-COPY --from=sliced-deps /status /var/lib/dpkg/status
+COPY --from=builder /rootfs /
+COPY --from=builder /status /var/lib/dpkg/status
 
-FROM image-prep
+FROM scratch
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
 ARG USER UID GROUP GID
 
-COPY --from=sliced-deps /rootfs /
+COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown="$UID:$GID" "/rootfs/home/$USER" "/home/$USER"
 
 # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -1,43 +1,24 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=app UID=101 GROUP=app GID=101
 
-FROM golang:1.20 AS chisel
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
-RUN chmod +x chisel-wrapper
-
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:c6871ae8b54fb3ed0ba4df4eb98527e9a6692088fe0c2f2260a9334853092b47 AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
+RUN chmod +x /usr/bin/chisel-wrapper
+
 RUN mkdir -p /rootfs/etc \
-    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && install -d -m 0755 -o "$UID" -g "$GID" "/rootfs/home/$USER" \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
-FROM scratch AS image-prep
-ENV \
-    # Configure web servers to bind to port 8080 when present
-    ASPNETCORE_URLS=http://+:8080 \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true
-ARG UID GID
-USER $UID:$GID
-
-### BOILERPLATE END ###
-
-FROM rootfs-prep AS sliced-runtime
-ARG UBUNTU_RELEASE
 RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -47,16 +28,21 @@ RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_R
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
 
 FROM scratch AS sbom-prep
-COPY --from=sliced-runtime /rootfs /
-COPY --from=sliced-runtime /status /var/lib/dpkg/status
+COPY --from=builder /rootfs /
+COPY --from=builder /status /var/lib/dpkg/status
 
-FROM image-prep
+FROM scratch
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
 ARG USER UID GROUP GID
 
-COPY --from=sliced-runtime /rootfs /
+COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=sliced-runtime --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown="$UID:$GID" "/rootfs/home/$USER" "/home/$USER"
 
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]


### PR DESCRIPTION
Download v0.8.0 chisel binary from GitHub release instead of building it. Additionally, do not download chisel-releases initially, chisel will fetch it as needed.

Merge a few stages to simplify the Dockerfiles.
