### PR TITLE
refactor(7.0): simplify build recipe

### DIFF
--- a/dotnet-aspnet/Dockerfile.23.04
+++ b/dotnet-aspnet/Dockerfile.23.04
@@ -1,15 +1,8 @@
 ARG UBUNTU_RELEASE=23.04
 ARG USER=app UID=101 GROUP=app GID=101
 
-FROM golang:1.20 AS chisel
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
-RUN chmod +x chisel-wrapper
-
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:f6bb94197c998019c372adbf67b61ee864204b5b0e57ec8a2c4db70ebf396f17 AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git file \
@@ -17,25 +10,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 ### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
 RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
-###
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
-FROM scratch AS image-prep
-ENV \
-    # Configure web servers to bind to port 8080 when present
-    ASPNETCORE_URLS=http://+:8080 \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
-ARG UID GID
-USER $UID:$GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
+RUN chmod +x /usr/bin/chisel-wrapper
 
-### BOILERPLATE END ###
-
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
     && chisel-wrapper --generate-dpkg-status /status -- --release ./chisel-releases --root /rootfs \
         base-files_base \
@@ -46,18 +26,27 @@ RUN mkdir /rootfs \
     #  "A fatal error was encountered. Cannot execute dotnet when renamed to dotnet7."
     && mv /rootfs/usr/lib/dotnet/dotnet7 /rootfs/usr/lib/dotnet/dotnet \
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
-RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+RUN install -d -m 0755 -o "$UID" -g "$GID" "/rootfs/home/$USER" \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS sbom-prep
-COPY --from=rootfs-prep /rootfs /
-COPY --from=rootfs-prep /status /var/lib/dpkg/status
+COPY --from=builder /rootfs /
+COPY --from=builder /status /var/lib/dpkg/status
 
-FROM image-prep
+FROM scratch
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 ARG USER UID GROUP GID
-COPY --from=rootfs-prep /rootfs /
+
+COPY --from=builder /rootfs /
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=rootfs-prep --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown="$UID:$GID" "/rootfs/home/$USER" "/home/$USER"
+
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]

--- a/dotnet-deps/Dockerfile.23.04
+++ b/dotnet-deps/Dockerfile.23.04
@@ -1,45 +1,24 @@
 ARG UBUNTU_RELEASE=23.04
 ARG USER=app UID=101 GROUP=app GID=101
 
-FROM golang:1.20 AS chisel
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
-RUN chmod +x chisel-wrapper
-
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:f6bb94197c998019c372adbf67b61ee864204b5b0e57ec8a2c4db70ebf396f17 AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
+RUN chmod +x /usr/bin/chisel-wrapper
+
 RUN mkdir -p /rootfs/etc \
-    && install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && install -d -m 0755 -o "$UID" -g "$GID" "/rootfs/home/$USER" \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
-FROM scratch AS image-prep
-ENV \
-    # Configure web servers to bind to port 8080 when present
-    ASPNETCORE_URLS=http://+:8080 \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
-ARG UID GID
-USER $UID:$GID
-
-### BOILERPLATE END ###
-
-FROM rootfs-prep AS sliced-deps
-ARG UBUNTU_RELEASE
 RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_RELEASE" --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -51,13 +30,20 @@ RUN chisel-wrapper --generate-dpkg-status /status -- --release "ubuntu-$UBUNTU_R
     zlib1g_libs
 
 FROM scratch AS sbom-prep
-COPY --from=sliced-deps /rootfs /
-COPY --from=sliced-deps /status /var/lib/dpkg/status
+COPY --from=builder /rootfs /
+COPY --from=builder /status /var/lib/dpkg/status
 
-FROM image-prep
+FROM scratch
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 ARG USER UID GROUP GID
 
-COPY --from=sliced-deps /rootfs /
+COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown="$UID:$GID" "/rootfs/home/$USER" "/home/$USER"

--- a/dotnet-runtime/Dockerfile.23.04
+++ b/dotnet-runtime/Dockerfile.23.04
@@ -1,15 +1,8 @@
 ARG UBUNTU_RELEASE=23.04
 ARG USER=app UID=101 GROUP=app GID=101
 
-FROM golang:1.20 AS chisel
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" chisel-wrapper
-RUN chmod +x chisel-wrapper
-
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:f6bb94197c998019c372adbf67b61ee864204b5b0e57ec8a2c4db70ebf396f17 AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git file \
@@ -17,25 +10,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 ### TODO: REMOVE "git" and this, once .net7 slices are merged upstream
 RUN git clone -b "ROCKS-358_dotnet7-lunar" https://github.com/cjdcordeiro/chisel-releases.git
-###
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-COPY --from=chisel /opt/chisel/chisel-wrapper /usr/bin/
 
-FROM scratch AS image-prep
-ENV \
-    # Configure web servers to bind to port 8080 when present
-    ASPNETCORE_URLS=http://+:8080 \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
-ARG UID GID USER GROUP
-USER $UID:$GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
+RUN chmod +x /usr/bin/chisel-wrapper
 
-### BOILERPLATE END ###
-
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID UBUNTU_RELEASE
 RUN mkdir /rootfs \
     && chisel-wrapper --generate-dpkg-status /status -- --release ./chisel-releases --root /rootfs \
         base-files_base \
@@ -46,18 +26,27 @@ RUN mkdir /rootfs \
     #  "A fatal error was encountered. Cannot execute dotnet when renamed to dotnet7."
     && mv /rootfs/usr/lib/dotnet/dotnet7 /rootfs/usr/lib/dotnet/dotnet \
     && ln -s /usr/lib/dotnet/dotnet /rootfs/usr/bin/
-RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+RUN install -d -m 0755 -o "$UID" -g "$GID" "/rootfs/home/$USER" \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 
 FROM scratch AS sbom-prep
-COPY --from=rootfs-prep /rootfs /
-COPY --from=rootfs-prep /status /var/lib/dpkg/status
-    
-FROM image-prep
+COPY --from=builder /rootfs /
+COPY --from=builder /status /var/lib/dpkg/status
+
+FROM scratch AS image-prep
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 ARG USER UID GROUP GID
-COPY --from=rootfs-prep /rootfs /
+
+COPY --from=builder /rootfs /
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=rootfs-prep --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown="$UID:$GID" "/rootfs/home/$USER" "/home/$USER"
+
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]


### PR DESCRIPTION
Download v0.8.0 chisel binary from GitHub release instead of building it. Additionally, do not download chisel-releases initially, chisel will fetch it as needed.

Merge a few stages to simplify the Dockerfiles.