### PR TITLE
refactor(6.0): add CHISEL_VERSION build arg

### DIFF
--- a/dotnet-aspnet/Dockerfile.22.04
+++ b/dotnet-aspnet/Dockerfile.22.04
@@ -1,8 +1,9 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=app UID=101 GROUP=app GID=101
+ARG CHISEL_VERSION=0.8.1
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:c88265b8f9e40ca21547aeecd90b688a167738fefda07b943cdf48f7d714d503 AS builder
-ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE CHISEL_VERSION
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 
 RUN apt-get update \
@@ -10,7 +11,7 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ADD "https://github.com/canonical/chisel/releases/download/v0.8.1/chisel_v0.8.1_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
 RUN chmod +x /usr/bin/chisel-wrapper

--- a/dotnet-deps/Dockerfile.22.04
+++ b/dotnet-deps/Dockerfile.22.04
@@ -1,15 +1,16 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=app UID=101 GROUP=app GID=101
+ARG CHISEL_VERSION=0.8.1
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:c88265b8f9e40ca21547aeecd90b688a167738fefda07b943cdf48f7d714d503 AS builder
-ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE CHISEL_VERSION
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ADD "https://github.com/canonical/chisel/releases/download/v0.8.1/chisel_v0.8.1_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
 RUN chmod +x /usr/bin/chisel-wrapper

--- a/dotnet-runtime/Dockerfile.22.04
+++ b/dotnet-runtime/Dockerfile.22.04
@@ -1,15 +1,16 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=app UID=101 GROUP=app GID=101
+ARG CHISEL_VERSION=0.8.1
 
 FROM ubuntu.azurecr.io/ubuntu:$UBUNTU_RELEASE@sha256:c88265b8f9e40ca21547aeecd90b688a167738fefda07b943cdf48f7d714d503 AS builder
-ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE CHISEL_VERSION
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates file \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ADD "https://github.com/canonical/chisel/releases/download/v0.8.1/chisel_v0.8.1_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 ADD "https://raw.githubusercontent.com/canonical/rocks-toolbox/main/chisel-wrapper" /usr/bin/chisel-wrapper
 RUN chmod +x /usr/bin/chisel-wrapper


### PR DESCRIPTION
This PR introduces a build argument `CHISEL_VERSION` to track and use proper/updated [chisel](https://github.com/ubuntu-rocks/dotnet/pull/github.com/canonical/chisel) version.