### PR TITLE
chore: add build recipe for s390x for dotnet 8

### DIFF
--- a/rockcraft.2.dotnet-runtime-8.0-24.04.yaml
+++ b/rockcraft.2.dotnet-runtime-8.0-24.04.yaml
@@ -5,3 +5,5 @@ platforms:
   amd64:
   arm64:
     build-on: [amd64]
+  s390x:
+    build-on: [amd64]

--- a/rockcraft.3.dotnet-aspnet-8.0-24.04.yaml
+++ b/rockcraft.3.dotnet-aspnet-8.0-24.04.yaml
@@ -5,3 +5,5 @@ platforms:
   amd64:
   arm64:
     build-on: [amd64]
+  s390x:
+    build-on: [amd64]


### PR DESCRIPTION
Fixes ROCKS-1145

#### Changes proposed in this pull request:
 - Add building recipe for arch s390x for dotnet 8 runtime and aspnet.
